### PR TITLE
#36 Create MetricCard component

### DIFF
--- a/src/components/Dashboard/MetricCard.css
+++ b/src/components/Dashboard/MetricCard.css
@@ -1,0 +1,96 @@
+/* =================================================================
+   MetricCard Component Styles
+   Uses semantic CSS variables from index.css for theme support.
+   ================================================================= */
+
+.metric-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  min-height: 120px;
+}
+
+/* Title */
+.metric-card__title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: 1.25;
+}
+
+/* Value row: value + unit side-by-side */
+.metric-card__value-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-1);
+}
+
+.metric-card__value {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1.2;
+}
+
+.metric-card__unit {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--color-text-muted);
+}
+
+/* Trend indicator */
+.metric-card__trend {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.metric-card__trend--up {
+  color: var(--color-success);
+}
+
+.metric-card__trend--down {
+  color: var(--color-danger);
+}
+
+.metric-card__trend--neutral {
+  color: var(--color-text-muted);
+}
+
+/* Loading shimmer state */
+.metric-card--loading .metric-card__shimmer {
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    to right,
+    var(--color-border),
+    var(--color-bg-hover),
+    var(--color-border)
+  );
+  background-size: 200% 100%;
+  animation: shimmer 2s infinite linear;
+}
+
+.metric-card--loading .metric-card__shimmer--title {
+  height: 0.875rem;
+  width: 40%;
+}
+
+.metric-card--loading .metric-card__shimmer--value {
+  height: 1.875rem;
+  width: 60%;
+}
+
+.metric-card--loading .metric-card__shimmer--trend {
+  height: 0.875rem;
+  width: 30%;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .metric-card--loading .metric-card__shimmer {
+    animation: none;
+  }
+}

--- a/src/components/Dashboard/MetricCard.jsx
+++ b/src/components/Dashboard/MetricCard.jsx
@@ -1,0 +1,119 @@
+import PropTypes from 'prop-types';
+import './MetricCard.css';
+
+/**
+ * Trend arrow characters and their ARIA descriptions.
+ */
+const TREND_CONFIG = {
+  up: { symbol: '\u25B2', label: 'Trending up', className: 'metric-card__trend--up' },
+  down: { symbol: '\u25BC', label: 'Trending down', className: 'metric-card__trend--down' },
+  neutral: { symbol: '\u2014', label: 'No change', className: 'metric-card__trend--neutral' },
+};
+
+/**
+ * Formats a display value, handling null/undefined gracefully.
+ * @param {*} value - The metric value.
+ * @returns {string} The formatted value or "--" placeholder.
+ */
+function formatValue(value) {
+  if (value === null || value === undefined || value === '') {
+    return '--';
+  }
+  return String(value);
+}
+
+/**
+ * MetricCard - A reusable card that displays a single key metric.
+ *
+ * Features:
+ * - Displays title, value with optional unit, and trend indicator
+ * - Green up arrow for positive trend, red down arrow for negative
+ * - Graceful handling of missing/undefined values (shows "--")
+ * - Shimmer loading state
+ * - Full ARIA support: heading, value, trend description
+ * - Uses existing .card CSS class and semantic CSS variables
+ *
+ * @param {Object} props
+ * @param {string} props.title - Metric label (e.g., "Revenue")
+ * @param {string|number} props.value - Metric value (e.g., "$394B")
+ * @param {string} [props.unit] - Optional unit label (e.g., "USD", "%")
+ * @param {'up'|'down'|'neutral'} [props.trend] - Trend direction
+ * @param {boolean} [props.loading=false] - Whether to show loading shimmer
+ * @param {string} [props.className] - Additional CSS classes
+ */
+export function MetricCard({
+  title,
+  value,
+  unit,
+  trend,
+  loading = false,
+  className = '',
+}) {
+  if (loading) {
+    return (
+      <div
+        className={`card metric-card metric-card--loading ${className}`.trim()}
+        role="status"
+        aria-label={`Loading ${title || 'metric'}`}
+        data-testid="metric-card"
+      >
+        <div className="metric-card__shimmer metric-card__shimmer--title" />
+        <div className="metric-card__shimmer metric-card__shimmer--value" />
+        <div className="metric-card__shimmer metric-card__shimmer--trend" />
+        <span className="sr-only">Loading {title || 'metric'}...</span>
+      </div>
+    );
+  }
+
+  const displayValue = formatValue(value);
+  const trendConfig = trend ? TREND_CONFIG[trend] : null;
+
+  // Build the accessible description for the card
+  const valueDescription = unit
+    ? `${displayValue} ${unit}`
+    : displayValue;
+
+  return (
+    <div
+      className={`card metric-card ${className}`.trim()}
+      data-testid="metric-card"
+    >
+      <h3 className="metric-card__title">{title}</h3>
+
+      <div className="metric-card__value-row">
+        <span
+          className="metric-card__value"
+          aria-label={`Value: ${valueDescription}`}
+        >
+          {displayValue}
+        </span>
+        {unit && (
+          <span className="metric-card__unit" aria-hidden="true">
+            {unit}
+          </span>
+        )}
+      </div>
+
+      {trendConfig && (
+        <span
+          className={`metric-card__trend ${trendConfig.className}`}
+          role="img"
+          aria-label={trendConfig.label}
+        >
+          {trendConfig.symbol}
+        </span>
+      )}
+    </div>
+  );
+}
+
+MetricCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  unit: PropTypes.string,
+  trend: PropTypes.oneOf(['up', 'down', 'neutral']),
+  loading: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default MetricCard;

--- a/src/components/Dashboard/__tests__/MetricCard.test.jsx
+++ b/src/components/Dashboard/__tests__/MetricCard.test.jsx
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MetricCard } from '../MetricCard';
+
+/**
+ * Helper: renders MetricCard with the given props.
+ */
+function renderCard(props = {}) {
+  return render(<MetricCard title="Revenue" {...props} />);
+}
+
+describe('MetricCard', () => {
+  // =========================================================================
+  // Basic rendering
+  // =========================================================================
+
+  it('renders without crashing with only required props', () => {
+    const { container } = renderCard();
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card).toBeTruthy();
+    expect(card.className).toContain('card');
+    expect(card.className).toContain('metric-card');
+  });
+
+  it('renders the title as an h3 heading', () => {
+    renderCard({ title: 'Free Cash Flow' });
+
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading).toBeTruthy();
+    expect(heading.textContent).toBe('Free Cash Flow');
+  });
+
+  // =========================================================================
+  // Value display
+  // =========================================================================
+
+  it('renders a string value correctly', () => {
+    renderCard({ value: '$394B' });
+
+    const valueEl = screen.getByLabelText('Value: $394B');
+    expect(valueEl).toBeTruthy();
+    expect(valueEl.textContent).toBe('$394B');
+  });
+
+  it('renders a numeric value correctly', () => {
+    renderCard({ value: 28.5 });
+
+    const valueEl = screen.getByLabelText('Value: 28.5');
+    expect(valueEl).toBeTruthy();
+    expect(valueEl.textContent).toBe('28.5');
+  });
+
+  it('renders zero value correctly (not as placeholder)', () => {
+    renderCard({ value: 0 });
+
+    const valueEl = screen.getByLabelText('Value: 0');
+    expect(valueEl).toBeTruthy();
+    expect(valueEl.textContent).toBe('0');
+  });
+
+  // =========================================================================
+  // Missing/undefined values — shows "--"
+  // =========================================================================
+
+  it('shows "--" when value is undefined', () => {
+    renderCard({ value: undefined });
+
+    const valueEl = screen.getByLabelText('Value: --');
+    expect(valueEl).toBeTruthy();
+    expect(valueEl.textContent).toBe('--');
+  });
+
+  it('shows "--" when value is null', () => {
+    renderCard({ value: null });
+
+    const valueEl = screen.getByLabelText('Value: --');
+    expect(valueEl).toBeTruthy();
+    expect(valueEl.textContent).toBe('--');
+  });
+
+  it('shows "--" when value is empty string', () => {
+    renderCard({ value: '' });
+
+    const valueEl = screen.getByLabelText('Value: --');
+    expect(valueEl).toBeTruthy();
+    expect(valueEl.textContent).toBe('--');
+  });
+
+  it('shows "--" when value prop is not provided', () => {
+    renderCard();
+
+    const valueEl = screen.getByLabelText('Value: --');
+    expect(valueEl).toBeTruthy();
+    expect(valueEl.textContent).toBe('--');
+  });
+
+  // =========================================================================
+  // Unit display
+  // =========================================================================
+
+  it('renders unit next to the value', () => {
+    const { container } = renderCard({ value: '28.5', unit: '%' });
+
+    const unitEl = container.querySelector('.metric-card__unit');
+    expect(unitEl).toBeTruthy();
+    expect(unitEl.textContent).toBe('%');
+    expect(unitEl.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('does not render unit element when unit is not provided', () => {
+    const { container } = renderCard({ value: '$394B' });
+
+    const unitEl = container.querySelector('.metric-card__unit');
+    expect(unitEl).toBeNull();
+  });
+
+  it('includes unit in value aria-label when unit is present', () => {
+    renderCard({ value: '28.5', unit: '%' });
+
+    const valueEl = screen.getByLabelText('Value: 28.5 %');
+    expect(valueEl).toBeTruthy();
+  });
+
+  // =========================================================================
+  // Trend indicators
+  // =========================================================================
+
+  it('shows green up arrow for trend="up"', () => {
+    const { container } = renderCard({ value: '$394B', trend: 'up' });
+
+    const trendEl = container.querySelector('.metric-card__trend');
+    expect(trendEl).toBeTruthy();
+    expect(trendEl.textContent).toBe('\u25B2');
+    expect(trendEl.className).toContain('metric-card__trend--up');
+    expect(trendEl.getAttribute('aria-label')).toBe('Trending up');
+    expect(trendEl.getAttribute('role')).toBe('img');
+  });
+
+  it('shows red down arrow for trend="down"', () => {
+    const { container } = renderCard({ value: '$394B', trend: 'down' });
+
+    const trendEl = container.querySelector('.metric-card__trend');
+    expect(trendEl).toBeTruthy();
+    expect(trendEl.textContent).toBe('\u25BC');
+    expect(trendEl.className).toContain('metric-card__trend--down');
+    expect(trendEl.getAttribute('aria-label')).toBe('Trending down');
+  });
+
+  it('shows neutral dash for trend="neutral"', () => {
+    const { container } = renderCard({ value: '$394B', trend: 'neutral' });
+
+    const trendEl = container.querySelector('.metric-card__trend');
+    expect(trendEl).toBeTruthy();
+    expect(trendEl.textContent).toBe('\u2014');
+    expect(trendEl.className).toContain('metric-card__trend--neutral');
+    expect(trendEl.getAttribute('aria-label')).toBe('No change');
+  });
+
+  it('does not render trend indicator when trend is not provided', () => {
+    const { container } = renderCard({ value: '$394B' });
+
+    const trendEl = container.querySelector('.metric-card__trend');
+    expect(trendEl).toBeNull();
+  });
+
+  // =========================================================================
+  // Loading state
+  // =========================================================================
+
+  it('renders shimmer placeholders when loading is true', () => {
+    const { container } = renderCard({ loading: true });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card).toBeTruthy();
+    expect(card.className).toContain('metric-card--loading');
+    expect(card.getAttribute('role')).toBe('status');
+    expect(card.getAttribute('aria-label')).toBe('Loading Revenue');
+  });
+
+  it('renders three shimmer elements when loading', () => {
+    const { container } = renderCard({ loading: true });
+
+    const shimmers = container.querySelectorAll('.metric-card__shimmer');
+    expect(shimmers.length).toBe(3);
+  });
+
+  it('includes sr-only loading text when loading', () => {
+    const { container } = renderCard({ loading: true });
+
+    const srOnly = container.querySelector('.sr-only');
+    expect(srOnly).toBeTruthy();
+    expect(srOnly.textContent).toBe('Loading Revenue...');
+  });
+
+  it('does not render title, value, or trend when loading', () => {
+    const { container } = renderCard({ loading: true, value: '$394B', trend: 'up' });
+
+    expect(container.querySelector('.metric-card__title')).toBeNull();
+    expect(container.querySelector('.metric-card__value')).toBeNull();
+    expect(container.querySelector('.metric-card__trend')).toBeNull();
+  });
+
+  it('uses fallback "metric" in loading label when title is not provided', () => {
+    const { container } = render(<MetricCard loading={true} title={undefined} />);
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card.getAttribute('aria-label')).toBe('Loading metric');
+  });
+
+  // =========================================================================
+  // Accessibility (ARIA)
+  // =========================================================================
+
+  it('has heading role for the title', () => {
+    renderCard({ value: '$394B' });
+
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading.textContent).toBe('Revenue');
+  });
+
+  it('trend indicator has role="img" with descriptive aria-label', () => {
+    const { container } = renderCard({ value: '$394B', trend: 'up' });
+
+    const trendEl = container.querySelector('.metric-card__trend');
+    expect(trendEl.getAttribute('role')).toBe('img');
+    expect(trendEl.getAttribute('aria-label')).toBe('Trending up');
+  });
+
+  it('value element has an aria-label describing the value', () => {
+    renderCard({ value: '$394B' });
+
+    const valueEl = screen.getByLabelText('Value: $394B');
+    expect(valueEl).toBeTruthy();
+  });
+
+  it('unit is hidden from screen readers (aria-hidden)', () => {
+    const { container } = renderCard({ value: '28.5', unit: '%' });
+
+    const unitEl = container.querySelector('.metric-card__unit');
+    expect(unitEl.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  // =========================================================================
+  // className forwarding
+  // =========================================================================
+
+  it('forwards className to the card container', () => {
+    const { container } = renderCard({ className: 'custom-metric' });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card.className).toContain('custom-metric');
+  });
+
+  it('preserves base classes when className is provided', () => {
+    const { container } = renderCard({ className: 'extra' });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card.className).toContain('card');
+    expect(card.className).toContain('metric-card');
+    expect(card.className).toContain('extra');
+  });
+
+  it('does not add trailing space when className is empty', () => {
+    const { container } = renderCard({ className: '' });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card.className).not.toMatch(/\s$/);
+  });
+
+  // =========================================================================
+  // All props together
+  // =========================================================================
+
+  it('renders correctly with all props provided', () => {
+    const { container } = renderCard({
+      title: 'Gross Margin',
+      value: '42.3',
+      unit: '%',
+      trend: 'up',
+    });
+
+    // Title
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading.textContent).toBe('Gross Margin');
+
+    // Value with unit in aria-label
+    const valueEl = screen.getByLabelText('Value: 42.3 %');
+    expect(valueEl.textContent).toBe('42.3');
+
+    // Unit
+    const unitEl = container.querySelector('.metric-card__unit');
+    expect(unitEl.textContent).toBe('%');
+
+    // Trend
+    const trendEl = container.querySelector('.metric-card__trend');
+    expect(trendEl.textContent).toBe('\u25B2');
+    expect(trendEl.className).toContain('metric-card__trend--up');
+  });
+
+  // =========================================================================
+  // Snapshot test
+  // =========================================================================
+
+  it('matches snapshot for a fully populated card', () => {
+    const { container } = renderCard({
+      title: 'Revenue',
+      value: '$394B',
+      unit: 'USD',
+      trend: 'up',
+    });
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for loading state', () => {
+    const { container } = renderCard({
+      title: 'Revenue',
+      loading: true,
+    });
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/Dashboard/__tests__/__snapshots__/DashboardLayout.test.jsx.snap
+++ b/src/components/Dashboard/__tests__/__snapshots__/DashboardLayout.test.jsx.snap
@@ -1,0 +1,101 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DashboardLayout > matches snapshot for full layout 1`] = `
+<div
+  class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6"
+  data-testid="dashboard-layout"
+>
+  <div
+    class="grid grid-cols-1 gap-6"
+  >
+    <section
+      aria-label="Company banner"
+    >
+      <div
+        class="card"
+      >
+        AAPL - Apple Inc.
+      </div>
+    </section>
+    <section
+      aria-label="Key metrics"
+    >
+      <div
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+      >
+        <article
+          aria-label="Metric 1"
+        >
+          <div
+            class="card"
+          >
+            Revenue: $394B
+          </div>
+        </article>
+        <article
+          aria-label="Metric 2"
+        >
+          <div
+            class="card"
+          >
+            FCF: $111B
+          </div>
+        </article>
+        <article
+          aria-label="Metric 3"
+        >
+          <div
+            class="card"
+          >
+            Margin: 28%
+          </div>
+        </article>
+      </div>
+    </section>
+    <section
+      aria-label="Primary chart"
+    >
+      <div
+        class="card"
+      >
+        Revenue Chart Placeholder
+      </div>
+    </section>
+    <section
+      aria-label="Secondary charts"
+    >
+      <div
+        class="grid grid-cols-1 lg:grid-cols-2 gap-6"
+      >
+        <article
+          aria-label="Chart 1"
+        >
+          <div
+            class="card"
+          >
+            Margin Chart
+          </div>
+        </article>
+        <article
+          aria-label="Chart 2"
+        >
+          <div
+            class="card"
+          >
+            Growth Chart
+          </div>
+        </article>
+      </div>
+    </section>
+    <section
+      aria-label="Valuation"
+    >
+      <div
+        class="card"
+      >
+        P/E Fair Value: $185
+      </div>
+    </section>
+  </div>
+</div>
+`;

--- a/src/components/Dashboard/__tests__/__snapshots__/MetricCard.test.jsx.snap
+++ b/src/components/Dashboard/__tests__/__snapshots__/MetricCard.test.jsx.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MetricCard > matches snapshot for a fully populated card 1`] = `
+<div
+  class="card metric-card"
+  data-testid="metric-card"
+>
+  <h3
+    class="metric-card__title"
+  >
+    Revenue
+  </h3>
+  <div
+    class="metric-card__value-row"
+  >
+    <span
+      aria-label="Value: $394B USD"
+      class="metric-card__value"
+    >
+      $394B
+    </span>
+    <span
+      aria-hidden="true"
+      class="metric-card__unit"
+    >
+      USD
+    </span>
+  </div>
+  <span
+    aria-label="Trending up"
+    class="metric-card__trend metric-card__trend--up"
+    role="img"
+  >
+    ▲
+  </span>
+</div>
+`;
+
+exports[`MetricCard > matches snapshot for loading state 1`] = `
+<div
+  aria-label="Loading Revenue"
+  class="card metric-card metric-card--loading"
+  data-testid="metric-card"
+  role="status"
+>
+  <div
+    class="metric-card__shimmer metric-card__shimmer--title"
+  />
+  <div
+    class="metric-card__shimmer metric-card__shimmer--value"
+  />
+  <div
+    class="metric-card__shimmer metric-card__shimmer--trend"
+  />
+  <span
+    class="sr-only"
+  >
+    Loading 
+    Revenue
+    ...
+  </span>
+</div>
+`;

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -1,1 +1,2 @@
 export { DashboardLayout, default } from './DashboardLayout';
+export { MetricCard } from './MetricCard';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,6 +22,7 @@ export { ThemeToggle } from './ThemeToggle';
 
 // Dashboard
 export { DashboardLayout } from './Dashboard';
+export { MetricCard } from './Dashboard';
 
 // Demo components (for development/testing)
 export { LoadingStatesDemo } from './LoadingStatesDemo';


### PR DESCRIPTION
## Summary
Creates the MetricCard component — a reusable metric display card with trend indicators, loading states, and full ARIA support.

Closes #36

## Changes
- `MetricCard.jsx` — Main component with title, value, unit, trend, loading props
- `MetricCard.css` — Styles with shimmer animation, theme support
- 31 tests covering rendering, accessibility, edge cases
- Barrel exports updated

## Checklist
- [x] Tests passing (31 new, 524 total)
- [x] Lint clean
- [x] Code review (syntax + security)
- [x] CI green (no CI configured)