### PR TITLE
#49 useChartTheme Hook

### DIFF
--- a/src/hooks/__tests__/useChartTheme.test.jsx
+++ b/src/hooks/__tests__/useChartTheme.test.jsx
@@ -166,7 +166,7 @@ describe('useChartTheme', () => {
       result.current.setTheme('dark');
     });
 
-    expect(result.current.chartTheme.tooltipBg).toBe('#1a2332');
+    expect(result.current.chartTheme.tooltipBg).toBe('#243044');
     expect(result.current.chartTheme.tooltipBorder).toBe('#334155');
   });
 

--- a/src/hooks/useChartTheme.js
+++ b/src/hooks/useChartTheme.js
@@ -48,7 +48,7 @@ const FALLBACK_THEMES = {
     textColor: '#e2e8f0',
     textMutedColor: '#64748b',
     gridColor: '#334155',
-    tooltipBg: '#1a2332',
+    tooltipBg: '#243044',
     tooltipBorder: '#334155',
   },
 };


### PR DESCRIPTION
Closes #49

Implements useChartTheme hook for reading CSS custom properties and providing Recharts-compatible theme configuration.

## Changes
- `src/hooks/useChartTheme.js` — reads --chart-1 through --chart-6, text/grid/tooltip colors with fallbacks
- `src/hooks/__tests__/useChartTheme.test.jsx` — 15 tests covering all themes and edge cases

## Checklist
- [x] Tests passing (15 tests)
- [x] Lint clean
- [x] Code review (syntax + security) — 1 MEDIUM fixed (tooltipBg fallback)
- [x] CI green