### PR TITLE
#66 MarginsChart Dashboard Integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,10 +8,12 @@ import {
   MetricCard,
   ChartContainer,
   FCFChart,
+  MarginsChart,
   DashboardSkeleton,
 } from './components/Dashboard'
 import { useCompanySearch } from './hooks/useCompanySearch'
 import gaapNormalizer from './utils/gaapNormalizer'
+import { calculateMargins } from './utils/calculateMargins'
 
 /**
  * Formats a large number into a human-readable string with suffix.
@@ -362,12 +364,15 @@ function App() {
                 />
               </ChartContainer>,
               <ChartContainer key="margins-chart" title="Margins" loading={false}>
-                <div
-                  className="flex items-center justify-center h-full"
-                  style={{ color: 'var(--color-text-muted)' }}
-                >
-                  Chart placeholder — Recharts integration coming in Issue #7
-                </div>
+                <MarginsChart
+                  data={calculateMargins({
+                    revenue: data?.metrics?.revenue?.annual,
+                    grossProfit: data?.metrics?.grossProfit?.annual,
+                    operatingIncome: data?.metrics?.operatingIncome?.annual,
+                    netIncome: data?.metrics?.netIncome?.annual,
+                  })}
+                  animationDisabled={false}
+                />
               </ChartContainer>,
             ]}
           />

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -141,9 +141,29 @@ vi.mock('../components/Dashboard', () => ({
       FCFChart mock
     </div>
   ),
+  MarginsChart: ({ data }) => (
+    <div data-testid="margins-chart" data-has-data={Array.isArray(data) && data.length > 0}>
+      MarginsChart mock
+    </div>
+  ),
   DashboardSkeleton: () => (
     <div data-testid="dashboard-skeleton">Loading skeleton...</div>
   ),
+}));
+
+// Mock calculateMargins utility
+vi.mock('../utils/calculateMargins', () => ({
+  calculateMargins: vi.fn((metrics) => {
+    if (!metrics || !metrics.revenue || metrics.revenue.length === 0) return [];
+    return metrics.revenue.map((entry) => ({
+      fiscalYear: entry.fiscalYear,
+      label: `FY${entry.fiscalYear}`,
+      grossMargin: 44.0,
+      operatingMargin: 31.0,
+      netMargin: 25.0,
+    }));
+  }),
+  default: vi.fn(),
 }));
 
 // =============================================================================


### PR DESCRIPTION
Closes #66. Part of #7. Wire MarginsChart into dashboard.

## Summary
- Import `MarginsChart` and `calculateMargins` into `App.jsx`
- Replace margins chart placeholder with live `<MarginsChart>` component
- Pass GAAP-normalized metric arrays (`revenue`, `grossProfit`, `operatingIncome`, `netIncome`) to `calculateMargins` utility
- Add `MarginsChart` mock and `calculateMargins` mock to `App.test.jsx`
- Integration tests already pass via ThemeProvider wrapper (same pattern as FCFChart)

## Files Modified
- `src/App.jsx` - Import MarginsChart + calculateMargins, replace placeholder
- `src/__tests__/App.test.jsx` - Add MarginsChart and calculateMargins mocks

## Test plan
- [x] `npm run lint` passes clean (0 errors in modified files)
- [x] `npm test -- --watchAll=false` all pass, no regressions (2920 passed)
- [x] MarginsChart renders with real data in dashboard
- [x] Dashboard integration tests pass with ThemeProvider context