### PR TITLE
#77 MetricCard Animations & Dashboard Wiring

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,136 +12,8 @@ import {
   DashboardSkeleton,
 } from './components/Dashboard'
 import { useCompanySearch } from './hooks/useCompanySearch'
-import gaapNormalizer from './utils/gaapNormalizer'
+import { useKeyMetrics } from './hooks/useKeyMetrics'
 import { calculateMargins } from './utils/calculateMargins'
-
-/**
- * Formats a large number into a human-readable string with suffix.
- * e.g., 394000000000 -> "$394.0B"
- *
- * @param {number|null} value - Raw numeric value
- * @param {string} [prefix='$'] - Currency prefix
- * @returns {string} Formatted value or '--' if null/undefined
- */
-function formatLargeNumber(value, prefix = '$') {
-  if (value === null || value === undefined) return '--'
-
-  const abs = Math.abs(value)
-  const sign = value < 0 ? '-' : ''
-
-  if (abs >= 1e12) return `${sign}${prefix}${(abs / 1e12).toFixed(1)}T`
-  if (abs >= 1e9) return `${sign}${prefix}${(abs / 1e9).toFixed(1)}B`
-  if (abs >= 1e6) return `${sign}${prefix}${(abs / 1e6).toFixed(1)}M`
-  if (abs >= 1e3) return `${sign}${prefix}${(abs / 1e3).toFixed(1)}K`
-  return `${sign}${prefix}${abs.toFixed(0)}`
-}
-
-/**
- * Formats a percentage value (e.g., 0.284 -> "28.4%")
- *
- * @param {number|null} value - Decimal ratio (0-1 range)
- * @returns {string} Formatted percentage or '--'
- */
-function formatPercentage(value) {
-  if (value === null || value === undefined) return '--'
-  return `${(value * 100).toFixed(1)}%`
-}
-
-/**
- * Determines the trend direction by comparing two annual values.
- *
- * @param {Array} annualData - Array of annual data points (most recent first)
- * @returns {'up'|'down'|'neutral'|undefined} Trend direction
- */
-function getTrend(annualData) {
-  if (!Array.isArray(annualData) || annualData.length < 2) return undefined
-  const current = annualData[0]?.value
-  const previous = annualData[1]?.value
-  if (current == null || previous == null) return undefined
-  if (current > previous) return 'up'
-  if (current < previous) return 'down'
-  return 'neutral'
-}
-
-/**
- * Extracts key metrics from normalized company data for MetricCard display.
- *
- * @param {Object} data - Normalized company data from useCompanySearch
- * @returns {Array<Object>} Array of metric card props
- */
-function extractMetrics(data) {
-  if (!data?.metrics) return []
-
-  const metrics = []
-
-  // Revenue
-  const revenueLatest = gaapNormalizer.getLatestValue(data.metrics.revenue)
-  if (revenueLatest) {
-    metrics.push({
-      title: 'Revenue',
-      value: formatLargeNumber(revenueLatest.value),
-      unit: revenueLatest.fiscalYear ? `FY${revenueLatest.fiscalYear}` : undefined,
-      trend: getTrend(data.metrics.revenue?.annual),
-    })
-  }
-
-  // Net Income
-  const netIncomeLatest = gaapNormalizer.getLatestValue(data.metrics.netIncome)
-  if (netIncomeLatest) {
-    metrics.push({
-      title: 'Net Income',
-      value: formatLargeNumber(netIncomeLatest.value),
-      unit: netIncomeLatest.fiscalYear ? `FY${netIncomeLatest.fiscalYear}` : undefined,
-      trend: getTrend(data.metrics.netIncome?.annual),
-    })
-  }
-
-  // Free Cash Flow
-  const fcfLatest = gaapNormalizer.getLatestValue(data.metrics.freeCashFlow)
-  if (fcfLatest) {
-    metrics.push({
-      title: 'Free Cash Flow',
-      value: formatLargeNumber(fcfLatest.value),
-      unit: fcfLatest.fiscalYear ? `FY${fcfLatest.fiscalYear}` : undefined,
-      trend: getTrend(data.metrics.freeCashFlow?.annual),
-    })
-  }
-
-  // Gross Margin (calculated from grossProfit / revenue)
-  const grossProfitLatest = gaapNormalizer.getLatestValue(data.metrics.grossProfit)
-  if (grossProfitLatest && revenueLatest && revenueLatest.value !== 0) {
-    const margin = grossProfitLatest.value / revenueLatest.value
-    metrics.push({
-      title: 'Gross Margin',
-      value: formatPercentage(margin),
-    })
-  }
-
-  // EPS
-  const epsLatest = gaapNormalizer.getLatestValue(data.metrics.eps)
-  if (epsLatest) {
-    metrics.push({
-      title: 'EPS',
-      value: `$${Number(epsLatest.value).toFixed(2)}`,
-      unit: epsLatest.fiscalYear ? `FY${epsLatest.fiscalYear}` : undefined,
-      trend: getTrend(data.metrics.eps?.annual),
-    })
-  }
-
-  // Operating Cash Flow
-  const ocfLatest = gaapNormalizer.getLatestValue(data.metrics.operatingCashFlow)
-  if (ocfLatest) {
-    metrics.push({
-      title: 'Operating Cash Flow',
-      value: formatLargeNumber(ocfLatest.value),
-      unit: ocfLatest.fiscalYear ? `FY${ocfLatest.fiscalYear}` : undefined,
-      trend: getTrend(data.metrics.operatingCashFlow?.annual),
-    })
-  }
-
-  // Limit to 6 metrics max for the grid layout
-  return metrics.slice(0, 6)
-}
 
 function App() {
   const { data, loading, error, metadata, searchCompany, clearError } = useCompanySearch()
@@ -153,8 +25,8 @@ function App() {
   // Show compact search in header when we have data or are loading (not in welcome state)
   const showCompactSearch = data || loading
 
-  // Extract formatted metrics from normalized data
-  const metricCards = data ? extractMetrics(data) : []
+  // Extract formatted metrics from normalized data using the hook
+  const metricCards = useKeyMetrics(data)
 
   return (
     <div
@@ -339,11 +211,12 @@ function App() {
             }
             metrics={metricCards.map((metric, index) => (
               <MetricCard
-                key={`${metric.title}-${index}`}
+                key={metric.id || `${metric.title}-${index}`}
                 title={metric.title}
                 value={metric.value}
                 unit={metric.unit}
                 trend={metric.trend}
+                style={{ '--card-index': index }}
               />
             ))}
             heroChart={

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -53,6 +53,13 @@ vi.mock('../utils/gaapNormalizer', () => ({
   },
 }));
 
+// Mock useKeyMetrics hook — returns metrics array based on data
+let mockKeyMetricsReturn = [];
+vi.mock('../hooks/useKeyMetrics', () => ({
+  useKeyMetrics: () => mockKeyMetricsReturn,
+  default: () => mockKeyMetricsReturn,
+}));
+
 // Mock TickerSearch to simplify — avoid autocomplete complexity
 vi.mock('../components/TickerSearch', () => ({
   TickerSearch: ({ variant, onSearch, isSearching, autoFocus, className }) => (
@@ -122,8 +129,8 @@ vi.mock('../components/Dashboard', () => ({
       {price !== undefined && <span data-testid="banner-price">{price}</span>}
     </div>
   ),
-  MetricCard: ({ title, value, unit, trend }) => (
-    <div data-testid={`metric-card-${title}`}>
+  MetricCard: ({ title, value, unit, trend, style }) => (
+    <div data-testid={`metric-card-${title}`} style={style}>
       <span data-testid="metric-title">{title}</span>
       <span data-testid="metric-value">{value}</span>
       {unit && <span data-testid="metric-unit">{unit}</span>}
@@ -240,6 +247,7 @@ function createMockCompanyData(overrides = {}) {
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockKeyMetricsReturn = [];
     mockHookReturn = {
       data: null,
       loading: false,
@@ -387,6 +395,14 @@ describe('App', () => {
     beforeEach(() => {
       mockData = createMockCompanyData();
       mockHookReturn.data = mockData;
+      mockKeyMetricsReturn = [
+        { id: 'revenue', title: 'Revenue', value: '$394.0B', unit: 'FY2024', trend: 'up' },
+        { id: 'eps', title: 'EPS', value: '$6.42', unit: 'FY2024', trend: 'up' },
+        { id: 'fcf', title: 'FCF', value: '$111.0B', unit: 'FY2024', trend: 'up' },
+        { id: 'gross-margin', title: 'Gross Margin', value: '28.4%', unit: 'FY2024', trend: undefined },
+        { id: 'debt-to-equity', title: 'Debt-to-Equity', value: '--', unit: 'Ratio', trend: undefined },
+        { id: 'market-cap', title: 'Market Cap', value: '--', unit: 'Awaiting price data', trend: undefined },
+      ];
     });
 
     it('renders DashboardLayout when data is loaded', () => {
@@ -420,8 +436,18 @@ describe('App', () => {
 
       expect(screen.getByTestId('dashboard-metrics')).toBeTruthy();
       expect(screen.getByTestId('metric-card-Revenue')).toBeTruthy();
-      expect(screen.getByTestId('metric-card-Net Income')).toBeTruthy();
-      expect(screen.getByTestId('metric-card-Free Cash Flow')).toBeTruthy();
+      expect(screen.getByTestId('metric-card-EPS')).toBeTruthy();
+      expect(screen.getByTestId('metric-card-FCF')).toBeTruthy();
+    });
+
+    it('passes --card-index style to MetricCard for staggered animation', () => {
+      render(<App />);
+
+      const revenueCard = screen.getByTestId('metric-card-Revenue');
+      expect(revenueCard.style.getPropertyValue('--card-index')).toBe('0');
+
+      const epsCard = screen.getByTestId('metric-card-EPS');
+      expect(epsCard.style.getPropertyValue('--card-index')).toBe('1');
     });
 
     it('formats revenue as large number', () => {
@@ -481,19 +507,25 @@ describe('App', () => {
   // ===========================================================================
 
   describe('Metrics Extraction', () => {
-    it('renders gross margin as percentage when gross profit and revenue available', () => {
+    it('renders gross margin from useKeyMetrics hook', () => {
       mockHookReturn.data = createMockCompanyData();
+      mockKeyMetricsReturn = [
+        { id: 'revenue', title: 'Revenue', value: '$394.0B', unit: 'FY2024', trend: 'up' },
+        { id: 'gross-margin', title: 'Gross Margin', value: '28.4%', unit: 'FY2024', trend: undefined },
+      ];
       render(<App />);
 
       expect(screen.getByTestId('metric-card-Gross Margin')).toBeTruthy();
       const marginCard = screen.getByTestId('metric-card-Gross Margin');
       const value = marginCard.querySelector('[data-testid="metric-value"]');
-      // 112B / 394B = 0.2842... -> "28.4%"
       expect(value.textContent).toBe('28.4%');
     });
 
-    it('renders EPS formatted with dollar sign and decimals', () => {
+    it('renders EPS from useKeyMetrics hook', () => {
       mockHookReturn.data = createMockCompanyData();
+      mockKeyMetricsReturn = [
+        { id: 'eps', title: 'EPS', value: '$6.42', unit: 'FY2024', trend: 'up' },
+      ];
       render(<App />);
 
       expect(screen.getByTestId('metric-card-EPS')).toBeTruthy();
@@ -504,6 +536,14 @@ describe('App', () => {
 
     it('renders at most 6 metrics', () => {
       mockHookReturn.data = createMockCompanyData();
+      mockKeyMetricsReturn = [
+        { id: 'revenue', title: 'Revenue', value: '$394.0B', unit: 'FY2024', trend: 'up' },
+        { id: 'eps', title: 'EPS', value: '$6.42', unit: 'FY2024', trend: 'up' },
+        { id: 'fcf', title: 'FCF', value: '$111.0B', unit: 'FY2024', trend: 'up' },
+        { id: 'gross-margin', title: 'Gross Margin', value: '28.4%', unit: 'FY2024', trend: undefined },
+        { id: 'debt-to-equity', title: 'Debt-to-Equity', value: '--', unit: 'Ratio', trend: undefined },
+        { id: 'market-cap', title: 'Market Cap', value: '--', unit: 'Awaiting price data', trend: undefined },
+      ];
       render(<App />);
 
       const metricsContainer = screen.getByTestId('dashboard-metrics');
@@ -513,6 +553,7 @@ describe('App', () => {
 
     it('handles company with no metrics gracefully', () => {
       mockHookReturn.data = createMockCompanyData({ metrics: {} });
+      mockKeyMetricsReturn = [];
       render(<App />);
 
       // Dashboard should still render, just without metrics section
@@ -532,12 +573,14 @@ describe('App', () => {
           },
         },
       });
+      mockKeyMetricsReturn = [
+        { id: 'revenue', title: 'Revenue', value: '$100.0B', unit: 'FY2024', trend: undefined },
+      ];
       render(<App />);
 
       expect(screen.getByTestId('metric-card-Revenue')).toBeTruthy();
-      // No net income, no FCF — those metric cards should not exist
-      expect(screen.queryByTestId('metric-card-Net Income')).toBeNull();
-      expect(screen.queryByTestId('metric-card-Free Cash Flow')).toBeNull();
+      // No FCF — that metric card should not exist
+      expect(screen.queryByTestId('metric-card-FCF')).toBeNull();
     });
   });
 

--- a/src/components/Dashboard/MetricCard.css
+++ b/src/components/Dashboard/MetricCard.css
@@ -8,6 +8,32 @@
   flex-direction: column;
   gap: var(--spacing-2);
   min-height: 120px;
+  animation: metric-card-enter 300ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+  animation-delay: calc(var(--card-index, 0) * 50ms);
+}
+
+/* Entrance animation keyframe */
+@keyframes metric-card-enter {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* Hover state — only on devices that support hover */
+@media (hover: hover) {
+  .metric-card {
+    transition: transform 200ms ease, box-shadow 200ms ease;
+  }
+
+  .metric-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-xl);
+  }
 }
 
 /* Title */
@@ -57,7 +83,7 @@
 }
 
 .metric-card__trend--neutral {
-  color: var(--color-text-muted);
+  color: var(--color-text-secondary);
 }
 
 /* Loading shimmer state */
@@ -107,6 +133,10 @@
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
+  .metric-card {
+    animation: none;
+  }
+
   .metric-card--loading .metric-card__shimmer {
     animation: none;
   }

--- a/src/components/Dashboard/MetricCard.jsx
+++ b/src/components/Dashboard/MetricCard.jsx
@@ -40,6 +40,7 @@ function formatValue(value) {
  * @param {'up'|'down'|'neutral'} [props.trend] - Trend direction
  * @param {boolean} [props.loading=false] - Whether to show loading shimmer
  * @param {string} [props.className] - Additional CSS classes
+ * @param {Object} [props.style] - Inline styles (e.g., for --card-index custom property)
  */
 export function MetricCard({
   title,
@@ -48,6 +49,7 @@ export function MetricCard({
   trend,
   loading = false,
   className = '',
+  style,
 }) {
   if (loading) {
     return (
@@ -56,6 +58,7 @@ export function MetricCard({
         role="status"
         aria-label={`Loading ${title || 'metric'}`}
         data-testid="metric-card"
+        style={style}
       >
         <div className="metric-card__shimmer metric-card__shimmer--title" />
         <div className="metric-card__shimmer metric-card__shimmer--value" />
@@ -77,6 +80,7 @@ export function MetricCard({
     <div
       className={`card metric-card ${className}`.trim()}
       data-testid="metric-card"
+      style={style}
     >
       <h3 className="metric-card__title">{title}</h3>
 
@@ -114,6 +118,7 @@ MetricCard.propTypes = {
   trend: PropTypes.oneOf(['up', 'down', 'neutral']),
   loading: PropTypes.bool,
   className: PropTypes.string,
+  style: PropTypes.object,
 };
 
 export default MetricCard;

--- a/src/components/Dashboard/__tests__/Dashboard.integration.test.jsx
+++ b/src/components/Dashboard/__tests__/Dashboard.integration.test.jsx
@@ -364,7 +364,7 @@ describe('Dashboard Integration Tests', () => {
   // ===========================================================================
 
   describe('Empty and edge-case data handling', () => {
-    it('IT-DASH-07: company with empty metrics renders dashboard without metric cards', () => {
+    it('IT-DASH-07: company with empty metrics renders dashboard with placeholder metric cards', () => {
       setHookState({ data: mockNullDataCompany });
       renderApp();
 
@@ -373,8 +373,13 @@ describe('Dashboard Integration Tests', () => {
       expect(screen.getByTestId('company-banner')).toBeTruthy();
       expect(screen.getByText('No Data Corp')).toBeTruthy();
 
-      // No metric cards should be rendered (all metrics are empty)
-      expect(screen.queryAllByTestId('metric-card').length).toBe(0);
+      // useKeyMetrics always returns 6 metric cards (with '--' for missing values)
+      expect(screen.queryAllByTestId('metric-card').length).toBe(6);
+
+      // All values should be '--' placeholders
+      const values = document.querySelectorAll('.metric-card__value');
+      const allPlaceholder = Array.from(values).every((v) => v.textContent === '--');
+      expect(allPlaceholder).toBe(true);
     });
 
     it('IT-DASH-09: company with 1 year of data renders single data points', () => {
@@ -420,9 +425,10 @@ describe('Dashboard Integration Tests', () => {
       const revenueHeading = headings.find((h) => h.textContent === 'Revenue');
       expect(revenueHeading).toBeTruthy();
 
-      // Net Income should exist (1 year)
-      const niHeading = headings.find((h) => h.textContent === 'Net Income');
-      expect(niHeading).toBeTruthy();
+      // useKeyMetrics returns fixed 6 metrics: Revenue, EPS, FCF, Gross Margin, D/E, Market Cap
+      // EPS should exist (even if value is '--' for empty annual data)
+      const epsHeading = headings.find((h) => h.textContent === 'EPS');
+      expect(epsHeading).toBeTruthy();
     });
 
     it('handles company with negative values correctly', () => {

--- a/src/components/Dashboard/__tests__/MetricCard.test.jsx
+++ b/src/components/Dashboard/__tests__/MetricCard.test.jsx
@@ -321,4 +321,58 @@ describe('MetricCard', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  // =========================================================================
+  // style prop forwarding
+  // =========================================================================
+
+  it('forwards style prop to the root element', () => {
+    const { container } = renderCard({
+      value: '$394B',
+      style: { '--card-index': 2 },
+    });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card.style.getPropertyValue('--card-index')).toBe('2');
+  });
+
+  it('forwards style prop to the root element in loading state', () => {
+    const { container } = renderCard({
+      loading: true,
+      style: { '--card-index': 3 },
+    });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card.style.getPropertyValue('--card-index')).toBe('3');
+  });
+
+  it('renders without error when style is undefined', () => {
+    const { container } = renderCard({ value: '$394B', style: undefined });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card).toBeTruthy();
+  });
+
+  // =========================================================================
+  // Entrance animation CSS class
+  // =========================================================================
+
+  it('applies the metric-card class that carries the entrance animation', () => {
+    const { container } = renderCard({ value: '$394B' });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card.className).toContain('metric-card');
+  });
+
+  it('supports staggered animation delay via --card-index custom property', () => {
+    const { container } = renderCard({
+      value: '$394B',
+      style: { '--card-index': 4 },
+    });
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    // The CSS uses animation-delay: calc(var(--card-index, 0) * 50ms)
+    // Verify the custom property is set on the element so CSS can pick it up
+    expect(card.style.getPropertyValue('--card-index')).toBe('4');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #77
Part of #8 (Key Metrics Summary Cards)
Sub-issue of Epic #1

### Dependencies
- #75 MetricCard Component (merged)
- #76 useKeyMetrics Hook (merged)

## Scope

Add entrance animations, hover states, accessibility color fixes, and wire `useKeyMetrics` into the dashboard via `App.jsx`.

## Checklist

- [ ] Entrance animation CSS (fade-in + slide-up with staggered delays)
- [ ] Hover states (subtle elevation/shadow transitions)
- [ ] WCAG neutral color fix (ensure AA contrast for neutral sentiment)
- [ ] Wire `useKeyMetrics` into `App.jsx` (render MetricCard grid)
- [ ] `prefers-reduced-motion` support (disable animations for users who prefer reduced motion)