### PR TITLE
#86 Update useKeyMetrics (Market Cap + P/E)

### DIFF
--- a/src/__tests__/KeyMetrics.integration.test.jsx
+++ b/src/__tests__/KeyMetrics.integration.test.jsx
@@ -2,7 +2,7 @@
  * Key Metrics Integration Tests
  *
  * Tests the full data flow from company search data through useKeyMetrics hook
- * to MetricCard rendering. Verifies that all 6 metric cards display correct
+ * to MetricCard rendering. Verifies that all 7 metric cards display correct
  * values, labels, trends, animations, and accessibility attributes when the
  * dashboard components work together.
  *
@@ -194,12 +194,12 @@ describe('Key Metrics Integration Tests', () => {
   // ===========================================================================
 
   describe('A. End-to-End Data Flow', () => {
-    it('renders 6 MetricCards when company data is loaded', () => {
+    it('renders 7 MetricCards when company data is loaded', () => {
       setHookState({ data: mockAppleData });
       renderApp();
 
       const metricCards = screen.getAllByTestId('metric-card');
-      expect(metricCards.length).toBe(6);
+      expect(metricCards.length).toBe(7);
     });
 
     it('displays Revenue value from fixture data', () => {
@@ -286,7 +286,7 @@ describe('Key Metrics Integration Tests', () => {
       expect(de.unit).toBe('Ratio');
     });
 
-    it('displays all 6 metrics in correct order: Revenue, EPS, FCF, Gross Margin, D/E, Market Cap', () => {
+    it('displays all 7 metrics in correct order: Revenue, EPS, FCF, Gross Margin, D/E, Market Cap, P/E Ratio', () => {
       setHookState({ data: mockAppleData });
       renderApp();
 
@@ -299,6 +299,7 @@ describe('Key Metrics Integration Tests', () => {
         'Gross Margin',
         'Debt-to-Equity',
         'Market Cap',
+        'P/E Ratio',
       ]);
     });
   });
@@ -571,18 +572,18 @@ describe('Key Metrics Integration Tests', () => {
   // ===========================================================================
 
   describe('D. Animation Integration', () => {
-    it('all 6 cards have the metric-card class for entrance animation', () => {
+    it('all 7 cards have the metric-card class for entrance animation', () => {
       setHookState({ data: mockAppleData });
       renderApp();
 
       const cards = screen.getAllByTestId('metric-card');
-      expect(cards.length).toBe(6);
+      expect(cards.length).toBe(7);
       cards.forEach((card) => {
         expect(card.className).toContain('metric-card');
       });
     });
 
-    it('cards have sequential --card-index values (0-5)', () => {
+    it('cards have sequential --card-index values (0-6)', () => {
       setHookState({ data: mockAppleData });
       renderApp();
 
@@ -601,12 +602,12 @@ describe('Key Metrics Integration Tests', () => {
       expect(cards[0].style.getPropertyValue('--card-index')).toBe('0');
     });
 
-    it('last card has --card-index of 5', () => {
+    it('last card has --card-index of 6', () => {
       setHookState({ data: mockAppleData });
       renderApp();
 
       const cards = screen.getAllByTestId('metric-card');
-      expect(cards[5].style.getPropertyValue('--card-index')).toBe('5');
+      expect(cards[6].style.getPropertyValue('--card-index')).toBe('6');
     });
 
     it('animation delay increases per card via --card-index CSS custom property', () => {
@@ -658,7 +659,7 @@ describe('Key Metrics Integration Tests', () => {
       });
       // If we reached here without errors, the class is properly applied
       // and the CSS rule in MetricCard.css handles reduced-motion
-      expect(cards.length).toBe(6);
+      expect(cards.length).toBe(7);
     });
   });
 
@@ -680,18 +681,18 @@ describe('Key Metrics Integration Tests', () => {
       expect(metricSkeletons.length).toBeGreaterThan(0);
     });
 
-    it('no data results in graceful empty state with 6 placeholder metric cards', () => {
+    it('no data results in graceful empty state with 7 placeholder metric cards', () => {
       setHookState({ data: mockNullDataCompany });
       mockCalculateDebtToEquity.mockReturnValue(null);
       renderApp();
 
-      // useKeyMetrics returns 6 metrics, all with '--' values
+      // useKeyMetrics returns 7 metrics, all with '--' values
       const cards = screen.getAllByTestId('metric-card');
-      expect(cards.length).toBe(6);
+      expect(cards.length).toBe(7);
 
       const values = document.querySelectorAll('.metric-card__value');
       const valueTexts = Array.from(values).map((v) => v.textContent);
-      // Revenue, EPS, FCF, Gross Margin all '--', D/E '--' (null return), Market Cap '--'
+      // Revenue, EPS, FCF, Gross Margin all '--', D/E '--' (null return), Market Cap '--', P/E '--'
       expect(valueTexts.every((v) => v === '--')).toBe(true);
     });
 
@@ -734,7 +735,7 @@ describe('Key Metrics Integration Tests', () => {
 
       expect(screen.queryByTestId('dashboard-skeleton')).toBeNull();
       const cards = screen.getAllByTestId('metric-card');
-      expect(cards.length).toBe(6);
+      expect(cards.length).toBe(7);
     });
 
     it('error state does not render metric cards', () => {
@@ -814,7 +815,7 @@ describe('Key Metrics Integration Tests', () => {
       renderApp();
 
       const valueElements = document.querySelectorAll('.metric-card__value');
-      expect(valueElements.length).toBe(6);
+      expect(valueElements.length).toBe(7);
       valueElements.forEach((valueEl) => {
         const ariaLabel = valueEl.getAttribute('aria-label');
         expect(ariaLabel).toBeTruthy();
@@ -831,7 +832,7 @@ describe('Key Metrics Integration Tests', () => {
 
       // All metric cards should be inside this section
       const cardsInSection = keyMetricsSection.querySelectorAll('[data-testid="metric-card"]');
-      expect(cardsInSection.length).toBe(6);
+      expect(cardsInSection.length).toBe(7);
     });
   });
 });

--- a/src/components/Dashboard/__tests__/Dashboard.integration.test.jsx
+++ b/src/components/Dashboard/__tests__/Dashboard.integration.test.jsx
@@ -373,8 +373,8 @@ describe('Dashboard Integration Tests', () => {
       expect(screen.getByTestId('company-banner')).toBeTruthy();
       expect(screen.getByText('No Data Corp')).toBeTruthy();
 
-      // useKeyMetrics always returns 6 metric cards (with '--' for missing values)
-      expect(screen.queryAllByTestId('metric-card').length).toBe(6);
+      // useKeyMetrics always returns 7 metric cards (with '--' for missing values)
+      expect(screen.queryAllByTestId('metric-card').length).toBe(7);
 
       // All values should be '--' placeholders
       const values = document.querySelectorAll('.metric-card__value');
@@ -425,7 +425,7 @@ describe('Dashboard Integration Tests', () => {
       const revenueHeading = headings.find((h) => h.textContent === 'Revenue');
       expect(revenueHeading).toBeTruthy();
 
-      // useKeyMetrics returns fixed 6 metrics: Revenue, EPS, FCF, Gross Margin, D/E, Market Cap
+      // useKeyMetrics returns fixed 7 metrics: Revenue, EPS, FCF, Gross Margin, D/E, Market Cap, P/E Ratio
       // EPS should exist (even if value is '--' for empty annual data)
       const epsHeading = headings.find((h) => h.textContent === 'EPS');
       expect(epsHeading).toBeTruthy();

--- a/src/hooks/__tests__/useKeyMetrics.test.js
+++ b/src/hooks/__tests__/useKeyMetrics.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useKeyMetrics } from '../useKeyMetrics';
 
@@ -79,6 +79,22 @@ function createMockNormalizedData(overrides = {}) {
   };
 }
 
+/**
+ * Creates a mock stock quote object matching FMP API / useStockQuote data shape.
+ */
+function createMockStockQuote(overrides = {}) {
+  return {
+    price: 178.72,
+    eps: 6.13,
+    pe: 29.15,
+    marketCap: 2810000000000,
+    sharesOutstanding: 15728700000,
+    changesPercentage: 1.25,
+    name: 'Apple Inc.',
+    ...overrides,
+  };
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -94,12 +110,12 @@ describe('useKeyMetrics', () => {
   // ===========================================================================
 
   describe('return structure', () => {
-    it('returns an array of 6 metric objects', () => {
+    it('returns an array of 7 metric objects', () => {
       calculateDebtToEquity.mockReturnValue({ ratio: 4.67, previousRatio: 5.96 });
 
       const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData()));
 
-      expect(result.current).toHaveLength(6);
+      expect(result.current).toHaveLength(7);
     });
 
     it('each metric has required properties: id, title, value, unit, trend', () => {
@@ -135,7 +151,7 @@ describe('useKeyMetrics', () => {
   // ===========================================================================
 
   describe('metric order and content', () => {
-    it('returns metrics in the correct order: Revenue, EPS, FCF, Gross Margin, D/E, Market Cap', () => {
+    it('returns metrics in the correct order: Revenue, EPS, FCF, Gross Margin, D/E, Market Cap, P/E Ratio', () => {
       calculateDebtToEquity.mockReturnValue({ ratio: 4.67, previousRatio: 5.96 });
 
       const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData()));
@@ -148,6 +164,7 @@ describe('useKeyMetrics', () => {
         'Gross Margin',
         'Debt-to-Equity',
         'Market Cap',
+        'P/E Ratio',
       ]);
     });
   });
@@ -345,29 +362,241 @@ describe('useKeyMetrics', () => {
   });
 
   // ===========================================================================
-  // Market Cap placeholder
+  // Market Cap — without stockQuote (backward compatible)
   // ===========================================================================
 
-  describe('Market Cap placeholder', () => {
-    it('shows "--" value', () => {
+  describe('Market Cap without stockQuote (backward compatible)', () => {
+    it('shows "--" value when stockQuote is not provided', () => {
       const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData()));
 
       const marketCap = result.current.find((m) => m.id === 'market-cap');
       expect(marketCap.value).toBe('--');
     });
 
-    it('shows "Awaiting price data" unit', () => {
+    it('shows "Awaiting price data" unit when stockQuote is not provided', () => {
       const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData()));
 
       const marketCap = result.current.find((m) => m.id === 'market-cap');
       expect(marketCap.unit).toBe('Awaiting price data');
     });
 
-    it('has undefined trend', () => {
+    it('has undefined trend when stockQuote is not provided', () => {
       const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData()));
 
       const marketCap = result.current.find((m) => m.id === 'market-cap');
       expect(marketCap.trend).toBeUndefined();
+    });
+
+    it('shows "--" when stockQuote is explicitly null', () => {
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), null));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.value).toBe('--');
+      expect(marketCap.unit).toBe('Awaiting price data');
+    });
+
+    it('shows "--" when stockQuote is explicitly undefined', () => {
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), undefined));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.value).toBe('--');
+      expect(marketCap.unit).toBe('Awaiting price data');
+    });
+  });
+
+  // ===========================================================================
+  // Market Cap — with stockQuote (live data)
+  // ===========================================================================
+
+  describe('Market Cap with stockQuote', () => {
+    it('fills Market Cap from stockQuote.marketCap', () => {
+      const quote = createMockStockQuote({ marketCap: 2810000000000 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.value).toBe('$2.8T');
+    });
+
+    it('formats Market Cap in trillions correctly ($X.XT)', () => {
+      const quote = createMockStockQuote({ marketCap: 3500000000000 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.value).toBe('$3.5T');
+    });
+
+    it('formats Market Cap in billions correctly ($X.XB)', () => {
+      const quote = createMockStockQuote({ marketCap: 2100000000 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.value).toBe('$2.1B');
+    });
+
+    it('formats Market Cap in millions correctly ($X.XM)', () => {
+      const quote = createMockStockQuote({ marketCap: 850000000 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.value).toBe('$850.0M');
+    });
+
+    it('shows "Live" unit when stockQuote provides marketCap', () => {
+      const quote = createMockStockQuote();
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.unit).toBe('Live');
+    });
+
+    it('derives up trend from positive changesPercentage', () => {
+      const quote = createMockStockQuote({ changesPercentage: 1.25 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.trend).toBe('up');
+    });
+
+    it('derives down trend from negative changesPercentage', () => {
+      const quote = createMockStockQuote({ changesPercentage: -2.50 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.trend).toBe('down');
+    });
+
+    it('derives neutral trend from zero changesPercentage', () => {
+      const quote = createMockStockQuote({ changesPercentage: 0 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.trend).toBe('neutral');
+    });
+
+    it('shows undefined trend when changesPercentage is missing', () => {
+      const quote = createMockStockQuote({ changesPercentage: undefined });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.trend).toBeUndefined();
+    });
+
+    it('shows "--" when stockQuote has missing marketCap field', () => {
+      const quote = createMockStockQuote({ marketCap: undefined });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.value).toBe('--');
+      expect(marketCap.unit).toBe('Awaiting price data');
+    });
+
+    it('shows "--" when stockQuote has null marketCap', () => {
+      const quote = createMockStockQuote({ marketCap: null });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const marketCap = result.current.find((m) => m.id === 'market-cap');
+      expect(marketCap.value).toBe('--');
+      expect(marketCap.unit).toBe('Awaiting price data');
+    });
+  });
+
+  // ===========================================================================
+  // P/E Ratio — without stockQuote (backward compatible)
+  // ===========================================================================
+
+  describe('P/E Ratio without stockQuote (backward compatible)', () => {
+    it('shows "--" value when stockQuote is not provided', () => {
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData()));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.value).toBe('--');
+    });
+
+    it('shows "Awaiting price data" unit when stockQuote is not provided', () => {
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData()));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.unit).toBe('Awaiting price data');
+    });
+
+    it('has undefined trend when stockQuote is not provided', () => {
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData()));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.trend).toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // P/E Ratio — with stockQuote (live data)
+  // ===========================================================================
+
+  describe('P/E Ratio with stockQuote', () => {
+    it('fills P/E from stockQuote.pe', () => {
+      const quote = createMockStockQuote({ pe: 29.15 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.value).toBe('29.1');
+    });
+
+    it('formats P/E correctly with one decimal place (XX.X)', () => {
+      const quote = createMockStockQuote({ pe: 15.678 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.value).toBe('15.7');
+    });
+
+    it('shows "TTM" unit when stockQuote provides pe', () => {
+      const quote = createMockStockQuote();
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.unit).toBe('TTM');
+    });
+
+    it('shows "--" when stockQuote has missing pe field', () => {
+      const quote = createMockStockQuote({ pe: undefined });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.value).toBe('--');
+      expect(pe.unit).toBe('Awaiting price data');
+    });
+
+    it('shows "--" when stockQuote has null pe', () => {
+      const quote = createMockStockQuote({ pe: null });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.value).toBe('--');
+      expect(pe.unit).toBe('Awaiting price data');
+    });
+
+    it('handles pe value of 0 (displays 0.0)', () => {
+      const quote = createMockStockQuote({ pe: 0 });
+
+      const { result } = renderHook(() => useKeyMetrics(createMockNormalizedData(), quote));
+
+      const pe = result.current.find((m) => m.id === 'pe-ratio');
+      expect(pe.value).toBe('0.0');
     });
   });
 
@@ -390,6 +619,14 @@ describe('useKeyMetrics', () => {
 
     it('returns empty array when normalizedData.metrics is missing', () => {
       const { result } = renderHook(() => useKeyMetrics({ ticker: 'AAPL' }));
+
+      expect(result.current).toEqual([]);
+    });
+
+    it('returns empty array even when stockQuote is provided but normalizedData is null', () => {
+      const quote = createMockStockQuote();
+
+      const { result } = renderHook(() => useKeyMetrics(null, quote));
 
       expect(result.current).toEqual([]);
     });
@@ -477,18 +714,18 @@ describe('useKeyMetrics', () => {
       const data = createMockNormalizedData();
 
       const { result, rerender } = renderHook(
-        ({ normalizedData }) => useKeyMetrics(normalizedData),
-        { initialProps: { normalizedData: data } }
+        ({ normalizedData, stockQuote }) => useKeyMetrics(normalizedData, stockQuote),
+        { initialProps: { normalizedData: data, stockQuote: null } }
       );
 
       const firstResult = result.current;
-      rerender({ normalizedData: data });
+      rerender({ normalizedData: data, stockQuote: null });
       const secondResult = result.current;
 
       expect(firstResult).toBe(secondResult);
     });
 
-    it('returns a new array reference when input changes', () => {
+    it('returns a new array reference when normalizedData changes', () => {
       const data1 = createMockNormalizedData();
       const data2 = createMockNormalizedData({
         revenue: {
@@ -502,12 +739,45 @@ describe('useKeyMetrics', () => {
       });
 
       const { result, rerender } = renderHook(
-        ({ normalizedData }) => useKeyMetrics(normalizedData),
-        { initialProps: { normalizedData: data1 } }
+        ({ normalizedData, stockQuote }) => useKeyMetrics(normalizedData, stockQuote),
+        { initialProps: { normalizedData: data1, stockQuote: null } }
       );
 
       const firstResult = result.current;
-      rerender({ normalizedData: data2 });
+      rerender({ normalizedData: data2, stockQuote: null });
+      const secondResult = result.current;
+
+      expect(firstResult).not.toBe(secondResult);
+    });
+
+    it('returns a new array reference when stockQuote changes', () => {
+      const data = createMockNormalizedData();
+      const quote1 = createMockStockQuote({ marketCap: 2800000000000 });
+      const quote2 = createMockStockQuote({ marketCap: 3000000000000 });
+
+      const { result, rerender } = renderHook(
+        ({ normalizedData, stockQuote }) => useKeyMetrics(normalizedData, stockQuote),
+        { initialProps: { normalizedData: data, stockQuote: quote1 } }
+      );
+
+      const firstResult = result.current;
+      rerender({ normalizedData: data, stockQuote: quote2 });
+      const secondResult = result.current;
+
+      expect(firstResult).not.toBe(secondResult);
+    });
+
+    it('returns a new array reference when stockQuote goes from null to a value', () => {
+      const data = createMockNormalizedData();
+      const quote = createMockStockQuote();
+
+      const { result, rerender } = renderHook(
+        ({ normalizedData, stockQuote }) => useKeyMetrics(normalizedData, stockQuote),
+        { initialProps: { normalizedData: data, stockQuote: null } }
+      );
+
+      const firstResult = result.current;
+      rerender({ normalizedData: data, stockQuote: quote });
       const secondResult = result.current;
 
       expect(firstResult).not.toBe(secondResult);

--- a/src/hooks/useKeyMetrics.js
+++ b/src/hooks/useKeyMetrics.js
@@ -1,8 +1,9 @@
 /**
  * useKeyMetrics - Hook that extracts key financial metrics from normalized data.
  *
- * Transforms gaapNormalizer output into an array of 6 metric card objects
- * for display in the dashboard MetricCard grid.
+ * Transforms gaapNormalizer output into an array of 7 metric card objects
+ * for display in the dashboard MetricCard grid. When a stockQuote is provided,
+ * Market Cap and P/E Ratio display live data; otherwise they show placeholders.
  *
  * @module useKeyMetrics
  */
@@ -102,7 +103,7 @@ function getDebtToEquityTrend(currentRatio, previousRatio) {
 // =============================================================================
 
 /**
- * useKeyMetrics extracts and formats 6 key financial metrics from normalized data.
+ * useKeyMetrics extracts and formats key financial metrics from normalized data.
  *
  * Returns an array of metric objects suitable for MetricCard components:
  * 1. Revenue (FY[Year])
@@ -110,12 +111,18 @@ function getDebtToEquityTrend(currentRatio, previousRatio) {
  * 3. FCF (FY[Year])
  * 4. Gross Margin (FY[Year])
  * 5. Debt-to-Equity (Ratio)
- * 6. Market Cap (placeholder)
+ * 6. Market Cap (live from stockQuote, or placeholder)
+ * 7. P/E Ratio (live from stockQuote, or placeholder)
  *
  * @param {Object|null} normalizedData - Output from gaapNormalizer.normalizeCompanyFacts
+ * @param {Object|null} [stockQuote=null] - Output from useStockQuote hook's data field
+ * @param {number} [stockQuote.marketCap] - Market capitalization in dollars
+ * @param {number} [stockQuote.pe] - Price-to-earnings ratio
+ * @param {number} [stockQuote.price] - Current stock price
+ * @param {number} [stockQuote.changesPercentage] - Daily price change percentage
  * @returns {Array<{ id: string, title: string, value: string, unit: string, trend: string|undefined }>}
  */
-export function useKeyMetrics(normalizedData) {
+export function useKeyMetrics(normalizedData, stockQuote = null) {
   return useMemo(() => {
     if (!normalizedData?.metrics) return [];
 
@@ -215,18 +222,51 @@ export function useKeyMetrics(normalizedData) {
     });
 
     // -----------------------------------------------------------------------
-    // 6. Market Cap (placeholder — deferred to #9)
+    // 6. Market Cap (live from stockQuote or placeholder)
     // -----------------------------------------------------------------------
-    metrics.push({
-      id: 'market-cap',
-      title: 'Market Cap',
-      value: '--',
-      unit: 'Awaiting price data',
-      trend: undefined,
-    });
+    if (stockQuote && stockQuote.marketCap != null) {
+      metrics.push({
+        id: 'market-cap',
+        title: 'Market Cap',
+        value: formatLargeNumber(stockQuote.marketCap),
+        unit: 'Live',
+        trend: stockQuote.changesPercentage != null
+          ? (stockQuote.changesPercentage > 0 ? 'up' : stockQuote.changesPercentage < 0 ? 'down' : 'neutral')
+          : undefined,
+      });
+    } else {
+      metrics.push({
+        id: 'market-cap',
+        title: 'Market Cap',
+        value: '--',
+        unit: 'Awaiting price data',
+        trend: undefined,
+      });
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. P/E Ratio (live from stockQuote or placeholder)
+    // -----------------------------------------------------------------------
+    if (stockQuote && stockQuote.pe != null) {
+      metrics.push({
+        id: 'pe-ratio',
+        title: 'P/E Ratio',
+        value: Number(stockQuote.pe).toFixed(1),
+        unit: 'TTM',
+        trend: undefined,
+      });
+    } else {
+      metrics.push({
+        id: 'pe-ratio',
+        title: 'P/E Ratio',
+        value: '--',
+        unit: 'Awaiting price data',
+        trend: undefined,
+      });
+    }
 
     return metrics;
-  }, [normalizedData]);
+  }, [normalizedData, stockQuote]);
 }
 
 export default useKeyMetrics;


### PR DESCRIPTION
## Summary
Closes #86
Part of #9
Depends on #85 (merged)

Replaces Market Cap "--" placeholder with live data from `useStockQuote`. Adds P/E ratio to key metrics display using real-time quote data.

## Changes
- Update `useKeyMetrics` hook to consume market cap and P/E from `useStockQuote`
- Replace hardcoded "--" placeholder with formatted live values
- Add proper number formatting for market cap display

## Test plan
- [ ] Verify market cap displays live value instead of "--"
- [ ] Verify P/E ratio displays correctly
- [ ] Unit tests for useKeyMetrics hook updates
- [ ] Integration test with mock useStockQuote data