### PR TITLE
#113 Dashboard Flow E2E Tests

### DIFF
--- a/e2e/helpers/mock-apis.js
+++ b/e2e/helpers/mock-apis.js
@@ -38,48 +38,42 @@ export async function mockAPIs(page, options = {}) {
   const { delay = 0, errorOnFacts = false, factsData } = options;
 
   // -----------------------------------------------------------------------
-  // 1. Company tickers (used by useTickerAutocomplete)
+  // 1. Company tickers (used by useTickerAutocomplete and edgarApi)
+  //    In development, Vite proxies /api/sec-tickers to SEC, so we must
+  //    intercept both the proxy path and the direct SEC URL.
   // -----------------------------------------------------------------------
+  const fulfillTickers = (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(COMPANY_TICKERS),
+    });
+
+  // Direct SEC URL (production builds)
   await page.route(
     '**/www.sec.gov/files/company_tickers.json',
-    (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(COMPANY_TICKERS),
-      }),
+    fulfillTickers,
   );
 
+  // Vite dev-server proxy path (development builds)
+  await page.route('**/api/sec-tickers', fulfillTickers);
+
   // -----------------------------------------------------------------------
-  // 2. Company facts — specific routes FIRST, wildcard LAST
-  //    Playwright matches first-registered first, so specific CIK routes
-  //    must be registered before the catch-all wildcard.
+  // 2. Company facts
+  //    Playwright matches routes in LIFO order (last registered wins).
+  //    Register the wildcard FIRST, then specific CIK overrides AFTER
+  //    so they take priority.
   // -----------------------------------------------------------------------
 
-  // AAPL (CIK 0000320193)
+  // Wildcard: any unknown CIK returns 404 (registered first = lowest priority)
   await page.route(
-    '**/data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json',
-    async (route) => {
-      if (errorOnFacts) {
-        return route.fulfill({
-          status: SEC_ERROR_RESPONSES.serverError.status,
-          contentType: SEC_ERROR_RESPONSES.serverError.contentType,
-          body: SEC_ERROR_RESPONSES.serverError.body,
-        });
-      }
-
-      const payload = factsData || AAPL_COMPANY_FACTS;
-
-      if (delay > 0) {
-        await new Promise((r) => setTimeout(r, delay));
-      }
-
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(payload),
-      });
-    },
+    '**/data.sec.gov/api/xbrl/companyfacts/CIK*.json',
+    (route) =>
+      route.fulfill({
+        status: SEC_ERROR_RESPONSES.notFound.status,
+        contentType: SEC_ERROR_RESPONSES.notFound.contentType,
+        body: SEC_ERROR_RESPONSES.notFound.body,
+      }),
   );
 
   // MSFT (CIK 0000789019)
@@ -106,15 +100,30 @@ export async function mockAPIs(page, options = {}) {
     },
   );
 
-  // Wildcard: any unknown CIK returns 404
+  // AAPL (CIK 0000320193) — registered last = highest priority
   await page.route(
-    '**/data.sec.gov/api/xbrl/companyfacts/CIK*.json',
-    (route) =>
-      route.fulfill({
-        status: SEC_ERROR_RESPONSES.notFound.status,
-        contentType: SEC_ERROR_RESPONSES.notFound.contentType,
-        body: SEC_ERROR_RESPONSES.notFound.body,
-      }),
+    '**/data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json',
+    async (route) => {
+      if (errorOnFacts) {
+        return route.fulfill({
+          status: SEC_ERROR_RESPONSES.serverError.status,
+          contentType: SEC_ERROR_RESPONSES.serverError.contentType,
+          body: SEC_ERROR_RESPONSES.serverError.body,
+        });
+      }
+
+      const payload = factsData || AAPL_COMPANY_FACTS;
+
+      if (delay > 0) {
+        await new Promise((r) => setTimeout(r, delay));
+      }
+
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(payload),
+      });
+    },
   );
 
   // -----------------------------------------------------------------------

--- a/e2e/regression/dashboard.spec.js
+++ b/e2e/regression/dashboard.spec.js
@@ -11,6 +11,9 @@ import { VIEWPORTS } from '../helpers/viewports.js';
 // and error boundary display.
 // ---------------------------------------------------------------------------
 
+/** Helper: build a data-testid locator from a SELECTORS string value. */
+const tid = (page, id) => page.getByTestId(id);
+
 test.describe('Dashboard Flow', () => {
   // -----------------------------------------------------------------------
   // RT-20: Dashboard layout renders all expected panels after search
@@ -20,62 +23,58 @@ test.describe('Dashboard Flow', () => {
     await page.goto('/');
 
     // Perform search
-    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    const input = tid(page, SELECTORS.tickerSearch.input).first();
     await input.click();
     await input.fill('AAPL');
     await input.press('Enter');
 
     // Wait for dashboard to fully render
-    const dashboard = page.locator(SELECTORS.DASHBOARD_LAYOUT);
-    await expect(dashboard).toBeVisible({ timeout: 10_000 });
+    await expect(tid(page, SELECTORS.dashboard.layout)).toBeVisible({ timeout: 10_000 });
 
     // Banner section
-    const banner = page.locator(SELECTORS.COMPANY_BANNER);
-    await expect(banner).toBeVisible();
+    await expect(tid(page, SELECTORS.companyBanner.root)).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Apple Inc.' })).toBeVisible();
 
     // Ticker badge
-    const tickerBadge = page.locator(SELECTORS.TICKER_BADGE);
-    await expect(tickerBadge).toHaveText('AAPL');
+    await expect(page.locator('[data-testid="ticker-badge"]')).toHaveText('AAPL');
 
     // Metric cards (at least 3 expected)
-    const metricCards = page.locator(SELECTORS.METRIC_CARD);
+    const metricCards = tid(page, SELECTORS.metricCard.root);
     await expect(metricCards.first()).toBeVisible();
     const metricCount = await metricCards.count();
     expect(metricCount).toBeGreaterThanOrEqual(3);
 
     // Chart containers (at least 1 expected)
-    const chartContainers = page.locator(SELECTORS.CHART_CONTAINER);
+    const chartContainers = tid(page, SELECTORS.charts.container);
     await expect(chartContainers.first()).toBeVisible();
     const chartCount = await chartContainers.count();
     expect(chartCount).toBeGreaterThanOrEqual(1);
 
     // Welcome state should be gone
-    await expect(page.locator(SELECTORS.WELCOME_STATE)).not.toBeVisible();
+    await expect(tid(page, SELECTORS.app.welcomeState)).not.toBeVisible();
   });
 
   // -----------------------------------------------------------------------
-  // RT-21: Mobile layout (375px) — single column, no horizontal overflow
+  // RT-21: Mobile layout (375px) -- single column, no horizontal overflow
   // -----------------------------------------------------------------------
   test('RT-21: Mobile layout is single column with no horizontal overflow', async ({ page }) => {
-    await page.setViewportSize(VIEWPORTS.MOBILE);
+    await page.setViewportSize(VIEWPORTS.mobile);
     await mockAPIs(page);
     await page.goto('/');
 
     // Perform search
-    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    const input = tid(page, SELECTORS.tickerSearch.input).first();
     await input.click();
     await input.fill('AAPL');
     await input.press('Enter');
 
     // Wait for dashboard
-    const dashboard = page.locator(SELECTORS.DASHBOARD_LAYOUT);
-    await expect(dashboard).toBeVisible({ timeout: 10_000 });
+    await expect(tid(page, SELECTORS.dashboard.layout)).toBeVisible({ timeout: 10_000 });
 
     // All major sections should be visible
-    await expect(page.locator(SELECTORS.COMPANY_BANNER)).toBeVisible();
-    await expect(page.locator(SELECTORS.METRIC_CARD).first()).toBeVisible();
-    await expect(page.locator(SELECTORS.CHART_CONTAINER).first()).toBeVisible();
+    await expect(tid(page, SELECTORS.companyBanner.root)).toBeVisible();
+    await expect(tid(page, SELECTORS.metricCard.root).first()).toBeVisible();
+    await expect(tid(page, SELECTORS.charts.container).first()).toBeVisible();
 
     // No horizontal overflow: document scroll width should not exceed viewport
     const hasOverflow = await page.evaluate(() => {
@@ -85,22 +84,21 @@ test.describe('Dashboard Flow', () => {
   });
 
   // -----------------------------------------------------------------------
-  // RT-22: Tablet layout (768px) — 2-column metric cards, stacked charts
+  // RT-22: Tablet layout (768px) -- 2-column metric cards, stacked charts
   // -----------------------------------------------------------------------
   test('RT-22: Tablet layout shows 2-column metrics and stacked charts', async ({ page }) => {
-    await page.setViewportSize(VIEWPORTS.TABLET);
+    await page.setViewportSize(VIEWPORTS.tablet);
     await mockAPIs(page);
     await page.goto('/');
 
     // Perform search
-    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    const input = tid(page, SELECTORS.tickerSearch.input).first();
     await input.click();
     await input.fill('AAPL');
     await input.press('Enter');
 
     // Wait for dashboard
-    const dashboard = page.locator(SELECTORS.DASHBOARD_LAYOUT);
-    await expect(dashboard).toBeVisible({ timeout: 10_000 });
+    await expect(tid(page, SELECTORS.dashboard.layout)).toBeVisible({ timeout: 10_000 });
 
     // Verify metrics grid is 2-column at 768px
     // The CSS rule at 768px: grid-template-columns: repeat(2, 1fr)
@@ -134,24 +132,24 @@ test.describe('Dashboard Flow', () => {
     await page.goto('/');
 
     // Perform search
-    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    const input = tid(page, SELECTORS.tickerSearch.input).first();
     await input.click();
     await input.fill('AAPL');
     await input.press('Enter');
 
     // Skeletons should appear while API is delayed
-    const skeleton = page.locator(SELECTORS.DASHBOARD_SKELETON);
+    const skeleton = tid(page, SELECTORS.dashboard.skeleton);
     await expect(skeleton).toBeVisible({ timeout: 5_000 });
 
     // Verify individual skeleton components are present
-    await expect(page.locator(SELECTORS.COMPANY_BANNER_SKELETON)).toBeVisible();
-    await expect(page.locator(SELECTORS.METRIC_CARD_SKELETON).first()).toBeVisible();
-    await expect(page.locator(SELECTORS.CHART_CONTAINER_SKELETON).first()).toBeVisible();
+    await expect(tid(page, SELECTORS.companyBanner.skeleton)).toBeVisible();
+    await expect(tid(page, SELECTORS.metricCard.skeleton).first()).toBeVisible();
+    await expect(tid(page, SELECTORS.charts.containerSkeleton).first()).toBeVisible();
 
     // After the delay resolves, the real dashboard should replace skeletons.
     // Wait for the real company banner (only rendered when data loads) rather
     // than dashboard-layout (which also exists inside DashboardSkeleton).
-    await expect(page.locator(SELECTORS.COMPANY_BANNER)).toBeVisible({ timeout: 15_000 });
+    await expect(tid(page, SELECTORS.companyBanner.root)).toBeVisible({ timeout: 15_000 });
     await expect(skeleton).not.toBeVisible();
   });
 
@@ -164,17 +162,17 @@ test.describe('Dashboard Flow', () => {
     await page.goto('/');
 
     // Perform search
-    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    const input = tid(page, SELECTORS.tickerSearch.input).first();
     await input.click();
     await input.fill('AAPL');
     await input.press('Enter');
 
     // Error state should appear
-    const errorState = page.locator(SELECTORS.ERROR_STATE);
+    const errorState = tid(page, SELECTORS.app.errorState);
     await expect(errorState).toBeVisible({ timeout: 10_000 });
 
     // Dashboard should NOT be visible
-    await expect(page.locator(SELECTORS.DASHBOARD_LAYOUT)).not.toBeVisible();
+    await expect(tid(page, SELECTORS.dashboard.layout)).not.toBeVisible();
 
     // A retry button should be available (btn-primary with RefreshCw icon)
     const retryButton = errorState.locator('button.btn-primary');

--- a/e2e/regression/dashboard.spec.js
+++ b/e2e/regression/dashboard.spec.js
@@ -1,0 +1,187 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { mockAPIs } from '../helpers/mock-apis.js';
+import { SELECTORS } from '../helpers/selectors.js';
+import { VIEWPORTS } from '../helpers/viewports.js';
+
+// ---------------------------------------------------------------------------
+// Dashboard Flow E2E Tests (RT-20 to RT-24)
+//
+// Covers dashboard layout rendering, responsive behaviour, loading skeletons,
+// and error boundary display.
+// ---------------------------------------------------------------------------
+
+test.describe('Dashboard Flow', () => {
+  // -----------------------------------------------------------------------
+  // RT-20: Dashboard layout renders all expected panels after search
+  // -----------------------------------------------------------------------
+  test('RT-20: Dashboard layout renders all sections after search', async ({ page }) => {
+    await mockAPIs(page);
+    await page.goto('/');
+
+    // Perform search
+    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    await input.click();
+    await input.fill('AAPL');
+    await input.press('Enter');
+
+    // Wait for dashboard to fully render
+    const dashboard = page.locator(SELECTORS.DASHBOARD_LAYOUT);
+    await expect(dashboard).toBeVisible({ timeout: 10_000 });
+
+    // Banner section
+    const banner = page.locator(SELECTORS.COMPANY_BANNER);
+    await expect(banner).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Apple Inc.' })).toBeVisible();
+
+    // Ticker badge
+    const tickerBadge = page.locator(SELECTORS.TICKER_BADGE);
+    await expect(tickerBadge).toHaveText('AAPL');
+
+    // Metric cards (at least 3 expected)
+    const metricCards = page.locator(SELECTORS.METRIC_CARD);
+    await expect(metricCards.first()).toBeVisible();
+    const metricCount = await metricCards.count();
+    expect(metricCount).toBeGreaterThanOrEqual(3);
+
+    // Chart containers (at least 1 expected)
+    const chartContainers = page.locator(SELECTORS.CHART_CONTAINER);
+    await expect(chartContainers.first()).toBeVisible();
+    const chartCount = await chartContainers.count();
+    expect(chartCount).toBeGreaterThanOrEqual(1);
+
+    // Welcome state should be gone
+    await expect(page.locator(SELECTORS.WELCOME_STATE)).not.toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // RT-21: Mobile layout (375px) — single column, no horizontal overflow
+  // -----------------------------------------------------------------------
+  test('RT-21: Mobile layout is single column with no horizontal overflow', async ({ page }) => {
+    await page.setViewportSize(VIEWPORTS.MOBILE);
+    await mockAPIs(page);
+    await page.goto('/');
+
+    // Perform search
+    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    await input.click();
+    await input.fill('AAPL');
+    await input.press('Enter');
+
+    // Wait for dashboard
+    const dashboard = page.locator(SELECTORS.DASHBOARD_LAYOUT);
+    await expect(dashboard).toBeVisible({ timeout: 10_000 });
+
+    // All major sections should be visible
+    await expect(page.locator(SELECTORS.COMPANY_BANNER)).toBeVisible();
+    await expect(page.locator(SELECTORS.METRIC_CARD).first()).toBeVisible();
+    await expect(page.locator(SELECTORS.CHART_CONTAINER).first()).toBeVisible();
+
+    // No horizontal overflow: document scroll width should not exceed viewport
+    const hasOverflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(hasOverflow).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // RT-22: Tablet layout (768px) — 2-column metric cards, stacked charts
+  // -----------------------------------------------------------------------
+  test('RT-22: Tablet layout shows 2-column metrics and stacked charts', async ({ page }) => {
+    await page.setViewportSize(VIEWPORTS.TABLET);
+    await mockAPIs(page);
+    await page.goto('/');
+
+    // Perform search
+    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    await input.click();
+    await input.fill('AAPL');
+    await input.press('Enter');
+
+    // Wait for dashboard
+    const dashboard = page.locator(SELECTORS.DASHBOARD_LAYOUT);
+    await expect(dashboard).toBeVisible({ timeout: 10_000 });
+
+    // Verify metrics grid is 2-column at 768px
+    // The CSS rule at 768px: grid-template-columns: repeat(2, 1fr)
+    const metricsGrid = page.locator('.dashboard-layout__metrics-grid');
+    await expect(metricsGrid).toBeVisible();
+    const gridColumns = await metricsGrid.evaluate((el) =>
+      window.getComputedStyle(el).getPropertyValue('grid-template-columns'),
+    );
+    // Should contain exactly 2 column values (e.g. "352px 352px")
+    const columnCount = gridColumns.trim().split(/\s+/).length;
+    expect(columnCount).toBe(2);
+
+    // Charts grid should be single column at 768px (2-col only at 1024px+)
+    const chartsGrid = page.locator('.dashboard-layout__charts-grid');
+    const chartsGridVisible = await chartsGrid.isVisible();
+    if (chartsGridVisible) {
+      const chartsColumns = await chartsGrid.evaluate((el) =>
+        window.getComputedStyle(el).getPropertyValue('grid-template-columns'),
+      );
+      const chartsColumnCount = chartsColumns.trim().split(/\s+/).length;
+      expect(chartsColumnCount).toBe(1);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // RT-23: Loading skeletons appear during data fetch
+  // -----------------------------------------------------------------------
+  test('RT-23: Loading skeletons appear while data is loading', async ({ page }) => {
+    // Use delayed API responses to observe loading state
+    await mockAPIs(page, { delay: 2000 });
+    await page.goto('/');
+
+    // Perform search
+    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    await input.click();
+    await input.fill('AAPL');
+    await input.press('Enter');
+
+    // Skeletons should appear while API is delayed
+    const skeleton = page.locator(SELECTORS.DASHBOARD_SKELETON);
+    await expect(skeleton).toBeVisible({ timeout: 5_000 });
+
+    // Verify individual skeleton components are present
+    await expect(page.locator(SELECTORS.COMPANY_BANNER_SKELETON)).toBeVisible();
+    await expect(page.locator(SELECTORS.METRIC_CARD_SKELETON).first()).toBeVisible();
+    await expect(page.locator(SELECTORS.CHART_CONTAINER_SKELETON).first()).toBeVisible();
+
+    // After the delay resolves, the real dashboard should replace skeletons.
+    // Wait for the real company banner (only rendered when data loads) rather
+    // than dashboard-layout (which also exists inside DashboardSkeleton).
+    await expect(page.locator(SELECTORS.COMPANY_BANNER)).toBeVisible({ timeout: 15_000 });
+    await expect(skeleton).not.toBeVisible();
+  });
+
+  // -----------------------------------------------------------------------
+  // RT-24: Error boundary displays when API returns error
+  // -----------------------------------------------------------------------
+  test('RT-24: Error boundary displays with retry when API errors', async ({ page }) => {
+    // Mock APIs to return 500 on companyfacts
+    await mockAPIs(page, { errorOnFacts: true });
+    await page.goto('/');
+
+    // Perform search
+    const input = page.locator(SELECTORS.TICKER_SEARCH_INPUT).first();
+    await input.click();
+    await input.fill('AAPL');
+    await input.press('Enter');
+
+    // Error state should appear
+    const errorState = page.locator(SELECTORS.ERROR_STATE);
+    await expect(errorState).toBeVisible({ timeout: 10_000 });
+
+    // Dashboard should NOT be visible
+    await expect(page.locator(SELECTORS.DASHBOARD_LAYOUT)).not.toBeVisible();
+
+    // A retry button should be available (btn-primary with RefreshCw icon)
+    const retryButton = errorState.locator('button.btn-primary');
+    await expect(retryButton).toBeVisible();
+
+    // A "Go Home" button should also be present
+    const goHomeButton = errorState.locator('button.btn-secondary');
+    await expect(goHomeButton).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #113

- **5 Playwright E2E tests** covering dashboard layout, responsive behavior, loading skeletons, and error boundaries (RT-20 through RT-24)
- **Fixed `mockAPIs()` helper** to intercept Vite dev-server proxy path (`/api/sec-tickers`) in addition to the direct SEC URL
- **Fixed Playwright route registration order** (LIFO) so specific CIK routes take priority over the wildcard `CIK*.json` catch-all
- **Updated test spec** to use new nested `SELECTORS` and lowercase `VIEWPORTS` from shared helpers

### Test Cases

| RT ID | Test Name | Status |
|-------|-----------|--------|
| RT-20 | Dashboard layout renders all sections after search | PASS |
| RT-21 | Mobile layout (375px) — single column, no overflow | PASS |
| RT-22 | Tablet layout (768px) — 2-col metrics, stacked charts | PASS |
| RT-23 | Loading skeletons appear during data fetch (2s delay) | PASS |
| RT-24 | Error boundary displays with retry on API error | PASS |

### Key Fixes

1. **Vite proxy mock**: In dev mode, `edgarApi.js` fetches `/api/sec-tickers` (proxied by Vite), not the direct SEC URL. Added route intercept for both paths.
2. **Route LIFO order**: Playwright matches routes last-registered-first. Reversed order so wildcard is registered first (lowest priority), specific CIK routes last (highest priority).
3. **Skeleton detection**: `DashboardSkeleton` renders a `DashboardLayout` internally, so waiting for `dashboard-layout` visibility doesn't prove data loaded. Wait for `company-banner` instead.

## Test plan

- [x] All 5 E2E tests pass locally (`npx playwright test e2e/regression/dashboard.spec.js --project=regression`)
- [x] All 5 pass in `chromium` project as well
- [x] Fixture validation tests pass (18 tests)
- [x] Existing unit tests pass (1602 tests, 52 files)
- [x] Zero `waitForTimeout()` calls
- [x] Each test annotated with RT-XX ID