### PR TITLE
#146 A3: AuthContext, AuthProvider & useAuth Hook

### DIFF
--- a/src/components/AuthGuard.jsx
+++ b/src/components/AuthGuard.jsx
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+import { useAuth } from '../hooks/useAuth';
+
+/**
+ * AuthGuard protects content that requires authentication.
+ *
+ * - Renders `children` when the user is authenticated.
+ * - Renders `fallback` (default: null) when the user is not authenticated.
+ * - Renders `loadingFallback` (default: null) while auth state is initializing.
+ *
+ * Note: The A4 sprint will replace the redirect fallback with a proper login
+ * route redirect once React Router is added to the project.
+ *
+ * @example
+ * // Basic usage — hide content from unauthenticated users
+ * <AuthGuard>
+ *   <DebatePanel />
+ * </AuthGuard>
+ *
+ * @example
+ * // With custom fallbacks
+ * <AuthGuard fallback={<LoginPrompt />} loadingFallback={<Spinner />}>
+ *   <UserDashboard />
+ * </AuthGuard>
+ *
+ * @param {object} props
+ * @param {import('react').ReactNode} props.children - Content to render when authenticated
+ * @param {import('react').ReactNode} [props.fallback] - Content to render when not authenticated
+ * @param {import('react').ReactNode} [props.loadingFallback] - Content to render during loading
+ * @returns {import('react').ReactNode}
+ */
+export function AuthGuard({ children, fallback = null, loadingFallback = null }) {
+  const { isAuthenticated, loading } = useAuth();
+
+  if (loading) {
+    return loadingFallback;
+  }
+
+  if (!isAuthenticated) {
+    return fallback;
+  }
+
+  return children;
+}
+
+AuthGuard.propTypes = {
+  children: PropTypes.node.isRequired,
+  fallback: PropTypes.node,
+  loadingFallback: PropTypes.node,
+};
+
+export default AuthGuard;

--- a/src/components/__tests__/AuthGuard.test.jsx
+++ b/src/components/__tests__/AuthGuard.test.jsx
@@ -1,0 +1,214 @@
+/**
+ * Tests for AuthGuard component
+ *
+ * UT-AUTH-GUARD-01 through UT-AUTH-GUARD-10
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { AuthGuard } from '../AuthGuard';
+import { AuthContext } from '../../contexts/AuthContext';
+
+// =============================================================================
+// Helpers: inject AuthContext value directly (bypass AuthProvider internals)
+// =============================================================================
+
+/**
+ * Wraps children in AuthContext.Provider with a given value.
+ * This lets us test AuthGuard in isolation without a real Firebase connection.
+ *
+ * @param {import('../contexts/AuthContext').AuthContextValue} value
+ * @param {React.ReactNode} children
+ */
+function renderWithAuth(value, children) {
+  return render(
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+const AUTHENTICATED_CTX = {
+  user: { uid: 'user-1', email: 'a@b.com', displayName: 'A' },
+  loading: false,
+  error: null,
+  signIn: vi.fn(),
+  signUp: vi.fn(),
+  signOut: vi.fn(),
+};
+
+const UNAUTHENTICATED_CTX = {
+  user: null,
+  loading: false,
+  error: null,
+  signIn: vi.fn(),
+  signUp: vi.fn(),
+  signOut: vi.fn(),
+};
+
+const LOADING_CTX = {
+  user: null,
+  loading: true,
+  error: null,
+  signIn: vi.fn(),
+  signUp: vi.fn(),
+  signOut: vi.fn(),
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AuthGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // UT-AUTH-GUARD-01: Renders children when authenticated
+  it('renders children when user is authenticated', () => {
+    const { getByTestId } = renderWithAuth(
+      AUTHENTICATED_CTX,
+      <AuthGuard>
+        <div data-testid="protected">Protected Content</div>
+      </AuthGuard>
+    );
+
+    expect(getByTestId('protected')).toBeDefined();
+  });
+
+  // UT-AUTH-GUARD-02: Does not render children when unauthenticated
+  it('does not render children when user is not authenticated', () => {
+    const { queryByTestId } = renderWithAuth(
+      UNAUTHENTICATED_CTX,
+      <AuthGuard>
+        <div data-testid="protected">Protected Content</div>
+      </AuthGuard>
+    );
+
+    expect(queryByTestId('protected')).toBeNull();
+  });
+
+  // UT-AUTH-GUARD-03: Renders fallback when unauthenticated
+  it('renders fallback when user is not authenticated', () => {
+    const { getByTestId, queryByTestId } = renderWithAuth(
+      UNAUTHENTICATED_CTX,
+      <AuthGuard fallback={<div data-testid="login-prompt">Please log in</div>}>
+        <div data-testid="protected">Protected Content</div>
+      </AuthGuard>
+    );
+
+    expect(getByTestId('login-prompt')).toBeDefined();
+    expect(queryByTestId('protected')).toBeNull();
+  });
+
+  // UT-AUTH-GUARD-04: Renders null fallback by default when unauthenticated
+  it('renders nothing (null) by default when unauthenticated and no fallback provided', () => {
+    const { container } = renderWithAuth(
+      UNAUTHENTICATED_CTX,
+      <AuthGuard>
+        <div>Protected</div>
+      </AuthGuard>
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  // UT-AUTH-GUARD-05: Shows loadingFallback during loading
+  it('renders loadingFallback during auth initialization', () => {
+    const { getByTestId, queryByTestId } = renderWithAuth(
+      LOADING_CTX,
+      <AuthGuard
+        loadingFallback={<div data-testid="spinner">Loading...</div>}
+      >
+        <div data-testid="protected">Protected Content</div>
+      </AuthGuard>
+    );
+
+    expect(getByTestId('spinner')).toBeDefined();
+    expect(queryByTestId('protected')).toBeNull();
+  });
+
+  // UT-AUTH-GUARD-06: Renders nothing during loading when no loadingFallback
+  it('renders nothing during loading when no loadingFallback provided', () => {
+    const { container } = renderWithAuth(
+      LOADING_CTX,
+      <AuthGuard>
+        <div>Protected</div>
+      </AuthGuard>
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  // UT-AUTH-GUARD-07: Does not render loadingFallback when authenticated
+  it('does not show loadingFallback when loading=false and user is authenticated', () => {
+    const { queryByTestId, getByTestId } = renderWithAuth(
+      AUTHENTICATED_CTX,
+      <AuthGuard
+        loadingFallback={<div data-testid="spinner">Loading...</div>}
+      >
+        <div data-testid="protected">Protected</div>
+      </AuthGuard>
+    );
+
+    expect(queryByTestId('spinner')).toBeNull();
+    expect(getByTestId('protected')).toBeDefined();
+  });
+
+  // UT-AUTH-GUARD-08: Does not render fallback when authenticated
+  it('does not show fallback when user is authenticated', () => {
+    const { queryByTestId, getByTestId } = renderWithAuth(
+      AUTHENTICATED_CTX,
+      <AuthGuard fallback={<div data-testid="login-prompt">Please log in</div>}>
+        <div data-testid="protected">Protected</div>
+      </AuthGuard>
+    );
+
+    expect(queryByTestId('login-prompt')).toBeNull();
+    expect(getByTestId('protected')).toBeDefined();
+  });
+
+  // UT-AUTH-GUARD-09: Throws when used outside AuthProvider
+  it('throws when used outside AuthProvider (no AuthContext)', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      render(
+        <AuthGuard>
+          <div>Protected</div>
+        </AuthGuard>
+      );
+    }).toThrow('useAuth must be used within an AuthProvider');
+
+    consoleSpy.mockRestore();
+  });
+
+  // UT-AUTH-GUARD-10: Transitions from loading to authenticated
+  it('transitions from loadingFallback to children when auth state resolves to authenticated', () => {
+    // Render a controlled wrapper that accepts ctxValue as prop
+    function ControlledWrapper({ ctxValue }) {
+      return (
+        <AuthContext.Provider value={ctxValue}>
+          <AuthGuard
+            loadingFallback={<div data-testid="spinner">Loading...</div>}
+            fallback={<div data-testid="login">Login</div>}
+          >
+            <div data-testid="protected">Protected</div>
+          </AuthGuard>
+        </AuthContext.Provider>
+      );
+    }
+
+    const { queryByTestId, getByTestId, rerender } = render(
+      <ControlledWrapper ctxValue={LOADING_CTX} />
+    );
+
+    expect(getByTestId('spinner')).toBeDefined();
+    expect(queryByTestId('protected')).toBeNull();
+
+    rerender(<ControlledWrapper ctxValue={AUTHENTICATED_CTX} />);
+
+    expect(queryByTestId('spinner')).toBeNull();
+    expect(getByTestId('protected')).toBeDefined();
+  });
+});

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,0 +1,24 @@
+import { createContext } from 'react';
+
+/**
+ * @typedef {Object} AuthUser
+ * @property {string} uid - Firebase user ID
+ * @property {string|null} email - User email
+ * @property {string|null} displayName - User display name
+ */
+
+/**
+ * @typedef {Object} AuthContextValue
+ * @property {AuthUser|null} user - Current authenticated user, or null if signed out
+ * @property {boolean} loading - True during Firebase auth state initialization
+ * @property {string|null} error - Last auth error message, or null
+ * @property {(email: string, password: string) => Promise<void>} signIn - Sign in with email/password
+ * @property {(email: string, password: string) => Promise<void>} signUp - Create new account
+ * @property {() => Promise<void>} signOut - Sign out current user
+ */
+
+/**
+ * AuthContext holds the current authentication state.
+ * Consumers should use the useAuth hook rather than accessing this directly.
+ */
+export const AuthContext = createContext(null);

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,0 +1,143 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { AuthContext } from './AuthContext';
+
+// Static imports — these will be mocked in tests via vi.mock.
+// The firebase.js module guards against missing env vars and exports null for auth
+// if Firebase is not configured.
+import { auth as firebaseAuth } from '../lib/firebase';
+import {
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut as firebaseSignOut,
+} from 'firebase/auth';
+
+/**
+ * AuthProvider manages the application authentication state.
+ *
+ * Responsibilities:
+ * - Subscribes to Firebase `onAuthStateChanged` and exposes auth state via AuthContext
+ * - Provides `signIn`, `signUp`, and `signOut` action functions
+ * - Sets `loading: true` during Firebase initialization, then `false` once state is known
+ * - Cleans up the auth listener on unmount
+ * - Gracefully handles the case where Firebase is not configured (auth === null)
+ *
+ * @param {{ children: React.ReactNode }} props
+ */
+export function AuthProvider({ children }) {
+  // If Firebase auth is not available, we're not in a loading state — start false.
+  // Otherwise start true until onAuthStateChanged fires.
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(() => !!firebaseAuth);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!firebaseAuth) {
+      // Firebase not configured — already initialized with loading=false
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(
+      firebaseAuth,
+      (firebaseUser) => {
+        setUser(
+          firebaseUser
+            ? {
+                uid: firebaseUser.uid,
+                email: firebaseUser.email,
+                displayName: firebaseUser.displayName,
+              }
+            : null
+        );
+        setLoading(false);
+      },
+      (authError) => {
+        setError(authError.message);
+        setLoading(false);
+      }
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  /**
+   * Signs in with email and password.
+   * Sets error state on failure.
+   *
+   * @param {string} email
+   * @param {string} password
+   * @returns {Promise<void>}
+   */
+  const signIn = useCallback(async (email, password) => {
+    if (!firebaseAuth) {
+      const msg = 'Firebase Auth is not available';
+      setError(msg);
+      throw new Error(msg);
+    }
+    setError(null);
+    try {
+      await signInWithEmailAndPassword(firebaseAuth, email, password);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    }
+  }, []);
+
+  /**
+   * Creates a new account with email and password.
+   * Sets error state on failure.
+   *
+   * @param {string} email
+   * @param {string} password
+   * @returns {Promise<void>}
+   */
+  const signUp = useCallback(async (email, password) => {
+    if (!firebaseAuth) {
+      const msg = 'Firebase Auth is not available';
+      setError(msg);
+      throw new Error(msg);
+    }
+    setError(null);
+    try {
+      await createUserWithEmailAndPassword(firebaseAuth, email, password);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    }
+  }, []);
+
+  /**
+   * Signs out the current user.
+   * Sets error state on failure.
+   *
+   * @returns {Promise<void>}
+   */
+  const signOut = useCallback(async () => {
+    if (!firebaseAuth) {
+      const msg = 'Firebase Auth is not available';
+      setError(msg);
+      throw new Error(msg);
+    }
+    setError(null);
+    try {
+      await firebaseSignOut(firebaseAuth);
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ user, loading, error, signIn, signUp, signOut }),
+    [user, loading, error, signIn, signUp, signOut]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/contexts/__tests__/AuthProvider.test.jsx
+++ b/src/contexts/__tests__/AuthProvider.test.jsx
@@ -1,0 +1,251 @@
+/**
+ * Tests for AuthProvider context component
+ *
+ * UT-AUTH-CTX-01 through UT-AUTH-CTX-10
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, renderHook, act, waitFor } from '@testing-library/react';
+import { useContext } from 'react';
+import { AuthProvider } from '../AuthProvider';
+import { AuthContext } from '../AuthContext';
+
+// =============================================================================
+// Firebase Auth mock — using vi.hoisted so variables are available at mock-hoist time
+// =============================================================================
+
+const {
+  mockAuth,
+  mockUnsubscribe,
+  mockOnAuthStateChangedSpy,
+  mockSignInWithEmailAndPassword,
+  mockCreateUserWithEmailAndPassword,
+  mockSignOut,
+  getCaptured,
+  setCaptured,
+} = vi.hoisted(() => {
+  let _capturedCallback = null;
+  let _capturedErrorCallback = null;
+  const _mockUnsubscribe = vi.fn();
+  const _mockAuth = {};
+
+  function _captureAuthState(auth, onNext, onError) {
+    _capturedCallback = onNext;
+    _capturedErrorCallback = onError;
+    return _mockUnsubscribe;
+  }
+  const _mockOnAuthStateChangedSpy = vi.fn(_captureAuthState);
+
+  return {
+    mockAuth: _mockAuth,
+    mockUnsubscribe: _mockUnsubscribe,
+    mockOnAuthStateChangedSpy: _mockOnAuthStateChangedSpy,
+    mockSignInWithEmailAndPassword: vi.fn(),
+    mockCreateUserWithEmailAndPassword: vi.fn(),
+    mockSignOut: vi.fn(),
+    getCaptured: () => ({ callback: _capturedCallback, errorCallback: _capturedErrorCallback }),
+    setCaptured: (cb, errCb) => {
+      _capturedCallback = cb;
+      _capturedErrorCallback = errCb;
+    },
+  };
+});
+
+vi.mock('../../lib/firebase', () => ({
+  auth: mockAuth,
+  firebaseAvailable: true,
+}));
+
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: (...args) => mockOnAuthStateChangedSpy(...args),
+  signInWithEmailAndPassword: (...args) => mockSignInWithEmailAndPassword(...args),
+  createUserWithEmailAndPassword: (...args) => mockCreateUserWithEmailAndPassword(...args),
+  signOut: (...args) => mockSignOut(...args),
+}));
+
+// =============================================================================
+// Helper Consumer
+// =============================================================================
+
+function AuthConsumer() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) return <div data-testid="no-context">No context</div>;
+  return (
+    <div>
+      <span data-testid="loading">{String(ctx.loading)}</span>
+      <span data-testid="user">{ctx.user ? ctx.user.uid : 'null'}</span>
+      <span data-testid="error">{ctx.error ?? 'null'}</span>
+      <span data-testid="is-authenticated">{String(ctx.user !== null)}</span>
+    </div>
+  );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore implementation after clearAllMocks so callback capture still works
+    mockOnAuthStateChangedSpy.mockImplementation((auth, onNext, onError) => {
+      setCaptured(onNext, onError);
+      return mockUnsubscribe;
+    });
+  });
+
+  // UT-AUTH-CTX-01: Renders children
+  it('renders children without crashing', () => {
+    const { getByText } = render(
+      <AuthProvider>
+        <span>child content</span>
+      </AuthProvider>
+    );
+    expect(getByText('child content')).toBeDefined();
+  });
+
+  // UT-AUTH-CTX-02: Initial loading state
+  it('provides loading=true initially before auth state resolves', async () => {
+    const { getByTestId } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>
+    );
+
+    // onAuthStateChanged is called synchronously in useEffect.
+    // The callback is captured but not yet fired, so loading remains true.
+    await waitFor(() => expect(mockOnAuthStateChangedSpy).toHaveBeenCalled());
+    expect(getByTestId('loading').textContent).toBe('true');
+    expect(getByTestId('user').textContent).toBe('null');
+  });
+
+  // UT-AUTH-CTX-03: Signed-out state after null user
+  it('provides user=null and loading=false after onAuthStateChanged emits null', async () => {
+    const { getByTestId } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(getCaptured().callback).not.toBe(null));
+
+    act(() => {
+      getCaptured().callback(null);
+    });
+
+    expect(getByTestId('loading').textContent).toBe('false');
+    expect(getByTestId('user').textContent).toBe('null');
+    expect(getByTestId('error').textContent).toBe('null');
+  });
+
+  // UT-AUTH-CTX-04: Signed-in state after Firebase user
+  it('provides user object and loading=false after onAuthStateChanged emits a user', async () => {
+    const { getByTestId } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(getCaptured().callback).not.toBe(null));
+
+    act(() => {
+      getCaptured().callback({ uid: 'abc', email: 'a@b.com', displayName: 'Alice' });
+    });
+
+    expect(getByTestId('loading').textContent).toBe('false');
+    expect(getByTestId('user').textContent).toBe('abc');
+    expect(getByTestId('error').textContent).toBe('null');
+  });
+
+  // UT-AUTH-CTX-05: Error state from auth state error callback
+  it('sets error and loading=false when onAuthStateChanged fires the error callback', async () => {
+    const { getByTestId } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(getCaptured().errorCallback).not.toBe(null));
+
+    act(() => {
+      getCaptured().errorCallback(new Error('auth/internal-error'));
+    });
+
+    expect(getByTestId('loading').textContent).toBe('false');
+    expect(getByTestId('error').textContent).toBe('auth/internal-error');
+  });
+
+  // UT-AUTH-CTX-06: Unsubscribes on unmount
+  it('calls the unsubscribe function returned by onAuthStateChanged on unmount', async () => {
+    const { unmount } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(mockOnAuthStateChangedSpy).toHaveBeenCalled());
+
+    unmount();
+
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+
+  // UT-AUTH-CTX-07: Exposes signIn function
+  it('exposes signIn function via context', async () => {
+    const { result } = renderHook(() => useContext(AuthContext), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+
+    await waitFor(() => expect(result.current).not.toBe(null));
+    expect(typeof result.current.signIn).toBe('function');
+  });
+
+  // UT-AUTH-CTX-08: Exposes signUp function
+  it('exposes signUp function via context', async () => {
+    const { result } = renderHook(() => useContext(AuthContext), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+
+    await waitFor(() => expect(result.current).not.toBe(null));
+    expect(typeof result.current.signUp).toBe('function');
+  });
+
+  // UT-AUTH-CTX-09: Exposes signOut function
+  it('exposes signOut function via context', async () => {
+    const { result } = renderHook(() => useContext(AuthContext), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+
+    await waitFor(() => expect(result.current).not.toBe(null));
+    expect(typeof result.current.signOut).toBe('function');
+  });
+
+  // UT-AUTH-CTX-10: User maps only expected fields from Firebase user
+  it('maps Firebase user to { uid, email, displayName } only', async () => {
+    const { result } = renderHook(() => useContext(AuthContext), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+
+    await waitFor(() => expect(getCaptured().callback).not.toBe(null));
+
+    act(() => {
+      getCaptured().callback({
+        uid: 'uid-999',
+        email: 'x@y.com',
+        displayName: 'X User',
+        // Extra Firebase fields that should NOT be forwarded
+        refreshToken: 'super-secret',
+        stsTokenManager: {},
+        providerData: [],
+      });
+    });
+
+    expect(result.current.user).toEqual({
+      uid: 'uid-999',
+      email: 'x@y.com',
+      displayName: 'X User',
+    });
+    expect(result.current.user).not.toHaveProperty('refreshToken');
+    expect(result.current.user).not.toHaveProperty('stsTokenManager');
+  });
+});

--- a/src/hooks/__tests__/useAuth.test.jsx
+++ b/src/hooks/__tests__/useAuth.test.jsx
@@ -1,0 +1,304 @@
+/**
+ * Tests for useAuth hook
+ *
+ * UT-AUTH-HOOK-01 through UT-AUTH-HOOK-12
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAuth } from '../useAuth';
+import { AuthProvider } from '../../contexts/AuthProvider';
+
+// =============================================================================
+// Firebase Auth mock — using vi.hoisted so variables are available at mock-hoist time
+// =============================================================================
+
+const {
+  mockAuth,
+  mockUnsubscribe,
+  mockOnAuthStateChanged,
+  mockSignInWithEmailAndPassword,
+  mockCreateUserWithEmailAndPassword,
+  mockSignOut,
+  getCapturedAuth,
+  setCapturedAuth,
+} = vi.hoisted(() => {
+  let _capturedCallback = null;
+  let _capturedErrorCallback = null;
+  const _mockUnsubscribe = vi.fn();
+  const _mockAuth = {};
+
+  function _captureAuthState(auth, onNext, onError) {
+    _capturedCallback = onNext;
+    _capturedErrorCallback = onError;
+    return _mockUnsubscribe;
+  }
+  const _mockOnAuthStateChanged = vi.fn(_captureAuthState);
+
+  return {
+    mockAuth: _mockAuth,
+    mockUnsubscribe: _mockUnsubscribe,
+    mockOnAuthStateChanged: _mockOnAuthStateChanged,
+    mockSignInWithEmailAndPassword: vi.fn(),
+    mockCreateUserWithEmailAndPassword: vi.fn(),
+    mockSignOut: vi.fn(),
+    getCapturedAuth: () => ({ callback: _capturedCallback, errorCallback: _capturedErrorCallback }),
+    setCapturedAuth: (cb, errCb) => {
+      _capturedCallback = cb;
+      _capturedErrorCallback = errCb;
+    },
+  };
+});
+
+vi.mock('../../lib/firebase', () => ({
+  auth: mockAuth,
+  firebaseAvailable: true,
+}));
+
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: (...args) => mockOnAuthStateChanged(...args),
+  signInWithEmailAndPassword: (...args) => mockSignInWithEmailAndPassword(...args),
+  createUserWithEmailAndPassword: (...args) => mockCreateUserWithEmailAndPassword(...args),
+  signOut: (...args) => mockSignOut(...args),
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function wrapper({ children }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+const MOCK_FIREBASE_USER = {
+  uid: 'user-123',
+  email: 'test@example.com',
+  displayName: 'Test User',
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore implementation after clearAllMocks so callback capture still works
+    mockOnAuthStateChanged.mockImplementation((auth, onNext, onError) => {
+      setCapturedAuth(onNext, onError);
+      return mockUnsubscribe;
+    });
+  });
+
+  // UT-AUTH-HOOK-01: Throws error when used outside AuthProvider
+  it('throws error when used outside AuthProvider', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useAuth());
+    }).toThrow('useAuth must be used within an AuthProvider');
+
+    consoleSpy.mockRestore();
+  });
+
+  // UT-AUTH-HOOK-02: Returns loading=true initially (before onAuthStateChanged fires)
+  it('returns loading=true initially', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    // onAuthStateChanged is called synchronously in useEffect.
+    // Callback is captured but not yet fired, so loading remains true.
+    await waitFor(() => {
+      expect(mockOnAuthStateChanged).toHaveBeenCalled();
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.user).toBe(null);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  // UT-AUTH-HOOK-03: Returns signed-out state after onAuthStateChanged fires with null
+  it('returns signed-out state when Firebase emits null user', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(null);
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.user).toBe(null);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  // UT-AUTH-HOOK-04: Returns authenticated state when Firebase emits a user
+  it('returns authenticated state when Firebase emits a user', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(MOCK_FIREBASE_USER);
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.user).toEqual({
+      uid: 'user-123',
+      email: 'test@example.com',
+      displayName: 'Test User',
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.error).toBe(null);
+  });
+
+  // UT-AUTH-HOOK-05: Returns complete interface shape
+  it('returns the complete interface (user, loading, error, isAuthenticated, signIn, signUp, signOut)', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(null);
+    });
+
+    expect(result.current).toHaveProperty('user');
+    expect(result.current).toHaveProperty('loading');
+    expect(result.current).toHaveProperty('error');
+    expect(result.current).toHaveProperty('isAuthenticated');
+    expect(result.current).toHaveProperty('signIn');
+    expect(result.current).toHaveProperty('signUp');
+    expect(result.current).toHaveProperty('signOut');
+
+    expect(typeof result.current.signIn).toBe('function');
+    expect(typeof result.current.signUp).toBe('function');
+    expect(typeof result.current.signOut).toBe('function');
+    expect(typeof result.current.isAuthenticated).toBe('boolean');
+  });
+
+  // UT-AUTH-HOOK-06: signIn delegates to Firebase
+  it('signIn calls Firebase signInWithEmailAndPassword', async () => {
+    mockSignInWithEmailAndPassword.mockResolvedValueOnce({ user: MOCK_FIREBASE_USER });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(null);
+    });
+
+    await act(async () => {
+      await result.current.signIn('test@example.com', 'password123');
+    });
+
+    expect(mockSignInWithEmailAndPassword).toHaveBeenCalledWith(
+      mockAuth,
+      'test@example.com',
+      'password123'
+    );
+  });
+
+  // UT-AUTH-HOOK-07: signUp delegates to Firebase
+  it('signUp calls Firebase createUserWithEmailAndPassword', async () => {
+    mockCreateUserWithEmailAndPassword.mockResolvedValueOnce({ user: MOCK_FIREBASE_USER });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(null);
+    });
+
+    await act(async () => {
+      await result.current.signUp('new@example.com', 'securepass');
+    });
+
+    expect(mockCreateUserWithEmailAndPassword).toHaveBeenCalledWith(
+      mockAuth,
+      'new@example.com',
+      'securepass'
+    );
+  });
+
+  // UT-AUTH-HOOK-08: signOut delegates to Firebase
+  it('signOut calls Firebase signOut', async () => {
+    mockSignOut.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(MOCK_FIREBASE_USER);
+    });
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    expect(mockSignOut).toHaveBeenCalledWith(mockAuth);
+  });
+
+  // UT-AUTH-HOOK-09: signIn sets error state on failure
+  it('signIn sets error state and rethrows when Firebase throws', async () => {
+    mockSignInWithEmailAndPassword.mockRejectedValueOnce(
+      new Error('auth/wrong-password')
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(null);
+    });
+
+    let caughtError;
+    await act(async () => {
+      try {
+        await result.current.signIn('test@example.com', 'wrong');
+      } catch (err) {
+        caughtError = err;
+      }
+    });
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError.message).toBe('auth/wrong-password');
+    await waitFor(() => expect(result.current.error).toBe('auth/wrong-password'));
+  });
+
+  // UT-AUTH-HOOK-10: error state from onAuthStateChanged error callback
+  it('sets error state when onAuthStateChanged emits an error', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(getCapturedAuth().errorCallback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().errorCallback(new Error('auth/network-request-failed'));
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe('auth/network-request-failed');
+  });
+
+  // UT-AUTH-HOOK-11: isAuthenticated is false when user is null
+  it('isAuthenticated is false when user is null', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(null);
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  // UT-AUTH-HOOK-12: isAuthenticated is true when user is set
+  it('isAuthenticated is true when user object is present', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(getCapturedAuth().callback).not.toBe(null));
+
+    act(() => {
+      getCapturedAuth().callback(MOCK_FIREBASE_USER);
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+});

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,39 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+
+/**
+ * useAuth provides access to the current authentication state and auth actions.
+ *
+ * Must be used within an AuthProvider. Throws a descriptive error if called outside one.
+ *
+ * @returns {{
+ *   user: import('../contexts/AuthContext').AuthUser|null,
+ *   loading: boolean,
+ *   error: string|null,
+ *   isAuthenticated: boolean,
+ *   signIn: (email: string, password: string) => Promise<void>,
+ *   signUp: (email: string, password: string) => Promise<void>,
+ *   signOut: () => Promise<void>
+ * }}
+ */
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (context === null) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  const { user, loading, error, signIn, signUp, signOut } = context;
+
+  return {
+    user,
+    loading,
+    error,
+    isAuthenticated: user !== null,
+    signIn,
+    signUp,
+    signOut,
+  };
+}
+
+export default useAuth;


### PR DESCRIPTION
## Summary

- Implements `AuthContext` (React Context) for auth state shape
- `AuthProvider` subscribes to Firebase `onAuthStateChanged`, cleans up on unmount, exposes `signIn`/`signUp`/`signOut` actions
- `useAuth()` hook consuming `AuthContext` with `isAuthenticated` derived field and helpful out-of-provider error
- `AuthGuard` component protecting content with `fallback` and `loadingFallback` props
- Gracefully handles unconfigured Firebase (no env vars) — starts with `loading: false` without calling `setState` in effect body

## Closes

Closes #146

## Tests

32 tests — all green:
- `useAuth.test.jsx` — 12 tests (throws outside provider, loading state, signed-in/out, interface shape, signIn/signUp/signOut delegation, error handling, isAuthenticated)
- `AuthProvider.test.jsx` — 10 tests (renders children, loading state, auth transitions, error state, unmount cleanup, context API surface, user field mapping)
- `AuthGuard.test.jsx` — 10 tests (authenticated renders, unauthenticated renders fallback, loading state, null fallbacks, throws outside provider, state transition)

## Test plan

- [ ] Run `npx vitest --run src/hooks/__tests__/useAuth.test.jsx src/contexts/__tests__/AuthProvider.test.jsx src/components/__tests__/AuthGuard.test.jsx` — expect 32/32 pass
- [ ] Run `npx eslint src/contexts/AuthContext.js src/contexts/AuthProvider.jsx src/hooks/useAuth.js src/components/AuthGuard.jsx` — expect 0 errors
- [ ] Verify `AuthProvider` can be added to `main.jsx` above `ThemeProvider` without breaking the app