### PR TITLE
#150 B2: Prompt Templates — Bull, Bear, Synthesis & Evaluation Harness

### DIFF
--- a/functions/src/__tests__/prompts/evaluation.test.ts
+++ b/functions/src/__tests__/prompts/evaluation.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * TDD RED phase — tests for the evaluation harness.
+ */
+describe('evaluateDebateOutput — schema validation', () => {
+  it('returns passed for a valid DebateOutput', async () => {
+    const { evaluateDebateOutput } = await import('../../services/prompts/evaluation.js');
+    const output = {
+      bullCase: {
+        arguments: [
+          { title: 'Revenue growth', detail: 'Apple grew revenue 8% YoY', citation: '10-K p.22' },
+        ],
+        confidence: 0.8,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      bearCase: {
+        riskFactors: [
+          { title: 'Competition', detail: 'Apple faces intense competition from Android', dataPoint: 'Market share flat in China' },
+        ],
+        confidence: 0.6,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      synthesis: {
+        keyFactors: [{ title: 'Valuation', analysis: 'P/E is elevated but justified by Apple moat' }],
+        recommendation: 'HOLD',
+        confidence: 0.7,
+        disclaimer: 'Not financial advice.',
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    const result = evaluateDebateOutput(output, 'Apple');
+    expect(result.passed).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns failed when bullCase is missing arguments', async () => {
+    const { evaluateDebateOutput } = await import('../../services/prompts/evaluation.js');
+    const output = {
+      bullCase: { arguments: [], confidence: 0.8, generatedAt: '2024-01-01T00:00:00.000Z' },
+      bearCase: {
+        riskFactors: [{ title: 'Risk', detail: 'Risk detail', dataPoint: 'Data point' }],
+        confidence: 0.5,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      synthesis: {
+        keyFactors: [{ title: 'Factor', analysis: 'Analysis' }],
+        recommendation: 'HOLD',
+        confidence: 0.6,
+        disclaimer: 'Not advice.',
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    const result = evaluateDebateOutput(output, 'SomeCompany');
+    expect(result.passed).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('returns failed when synthesis disclaimer is empty', async () => {
+    const { evaluateDebateOutput } = await import('../../services/prompts/evaluation.js');
+    const output = {
+      bullCase: {
+        arguments: [{ title: 'Growth', detail: 'Tesla grew strongly', citation: 'p.5' }],
+        confidence: 0.8,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      bearCase: {
+        riskFactors: [{ title: 'Risk', detail: 'Tesla faces competition', dataPoint: 'Share -3%' }],
+        confidence: 0.6,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      synthesis: {
+        keyFactors: [{ title: 'Valuation', analysis: 'High P/E' }],
+        recommendation: 'HOLD',
+        confidence: 0.6,
+        disclaimer: '',
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    const result = evaluateDebateOutput(output, 'Tesla');
+    expect(result.passed).toBe(false);
+    expect(result.errors.some(e => /disclaimer/i.test(e))).toBe(true);
+  });
+});
+
+describe('evaluateDebateOutput — content heuristics', () => {
+  it('warns when company name not present in bull case', async () => {
+    const { evaluateDebateOutput } = await import('../../services/prompts/evaluation.js');
+    const output = {
+      bullCase: {
+        arguments: [{ title: 'Growth', detail: 'Revenue grew strongly YoY', citation: 'p.5' }],
+        confidence: 0.8,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      bearCase: {
+        riskFactors: [{ title: 'Risk', detail: 'Microsoft faces cloud competition', dataPoint: 'AWS market share 32%' }],
+        confidence: 0.6,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      synthesis: {
+        keyFactors: [{ title: 'Factor', analysis: 'Microsoft analysis' }],
+        recommendation: 'HOLD',
+        confidence: 0.6,
+        disclaimer: 'Not financial advice.',
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    const result = evaluateDebateOutput(output, 'Microsoft');
+    // Bull case doesn't mention Microsoft — should fail content heuristic
+    expect(result.passed).toBe(false);
+    expect(result.errors.some(e => /company name/i.test(e))).toBe(true);
+  });
+
+  it('warns when bull and bear have duplicate argument titles', async () => {
+    const { evaluateDebateOutput } = await import('../../services/prompts/evaluation.js');
+    const output = {
+      bullCase: {
+        arguments: [{ title: 'Revenue growth', detail: 'Apple grew revenue 8%', citation: 'p.1' }],
+        confidence: 0.8,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      bearCase: {
+        riskFactors: [{ title: 'Revenue growth', detail: 'Apple revenue growth slowing', dataPoint: 'Growth -2%' }],
+        confidence: 0.5,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      synthesis: {
+        keyFactors: [{ title: 'Factor', analysis: 'Analysis of Apple' }],
+        recommendation: 'HOLD',
+        confidence: 0.6,
+        disclaimer: 'Not advice.',
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    const result = evaluateDebateOutput(output, 'Apple');
+    expect(result.passed).toBe(false);
+    expect(result.errors.some(e => /duplicate/i.test(e))).toBe(true);
+  });
+});
+
+describe('compareToGoldenFile', () => {
+  it('returns match:true when output structure matches golden file', async () => {
+    const { compareToGoldenFile } = await import('../../services/prompts/evaluation.js');
+    const output = {
+      bullCase: {
+        arguments: [{ title: 'Services Growth', detail: 'Apple services revenue', citation: '10-K p.5' }],
+        confidence: 0.85,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      bearCase: {
+        riskFactors: [{ title: 'Competition Risk', detail: 'Apple faces Android', dataPoint: 'Market share flat' }],
+        confidence: 0.65,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      synthesis: {
+        keyFactors: [{ title: 'Valuation', analysis: 'Apple P/E analysis' }],
+        recommendation: 'HOLD',
+        confidence: 0.75,
+        disclaimer: 'Not financial advice.',
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    const golden = { ...output };
+    const result = compareToGoldenFile(output, golden);
+    expect(result.match).toBe(true);
+  });
+
+  it('returns match:false when structure differs from golden file', async () => {
+    const { compareToGoldenFile } = await import('../../services/prompts/evaluation.js');
+    const output = {
+      bullCase: {
+        arguments: [{ title: 'Growth', detail: 'Apple grew', citation: 'p.1' }],
+        confidence: 0.8,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      bearCase: {
+        riskFactors: [{ title: 'Risk', detail: 'Apple competition', dataPoint: 'Data' }],
+        confidence: 0.5,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      synthesis: {
+        keyFactors: [{ title: 'Factor', analysis: 'Analysis' }],
+        recommendation: 'HOLD',
+        confidence: 0.6,
+        disclaimer: 'Not advice.',
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    // Golden has 2 bull arguments, actual has 1 — structural mismatch
+    const golden = {
+      ...output,
+      bullCase: {
+        arguments: [
+          { title: 'Services Growth', detail: 'Apple services', citation: 'p.5' },
+          { title: 'Hardware Moat', detail: 'Apple hardware', citation: 'p.8' },
+        ],
+        confidence: 0.85,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    const result = compareToGoldenFile(output, golden);
+    expect(result.match).toBe(false);
+    expect(result.differences.length).toBeGreaterThan(0);
+  });
+});

--- a/functions/src/__tests__/prompts/goldenFile.test.ts
+++ b/functions/src/__tests__/prompts/goldenFile.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * TDD RED phase — golden file regression tests.
+ * Ensures AAPL.json is a valid DebateOutput and passes the evaluator.
+ */
+describe('AAPL golden file', () => {
+  it('can be parsed as valid JSON', () => {
+    const filePath = join(__dirname, '../../services/prompts/goldenFiles/AAPL.json');
+    const raw = readFileSync(filePath, 'utf8');
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+
+  it('satisfies the DebateOutput schema', async () => {
+    const { isValidDebateOutput } = await import('../../services/prompts/types.js');
+    const filePath = join(__dirname, '../../services/prompts/goldenFiles/AAPL.json');
+    const output = JSON.parse(readFileSync(filePath, 'utf8'));
+    expect(isValidDebateOutput(output)).toBe(true);
+  });
+
+  it('passes the evaluation harness with company name Apple', async () => {
+    const { evaluateDebateOutput } = await import('../../services/prompts/evaluation.js');
+    const filePath = join(__dirname, '../../services/prompts/goldenFiles/AAPL.json');
+    const output = JSON.parse(readFileSync(filePath, 'utf8'));
+    const result = evaluateDebateOutput(output, 'Apple');
+    expect(result.passed).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('matches itself in golden file comparison (self-referential regression)', async () => {
+    const { compareToGoldenFile } = await import('../../services/prompts/evaluation.js');
+    const filePath = join(__dirname, '../../services/prompts/goldenFiles/AAPL.json');
+    const output = JSON.parse(readFileSync(filePath, 'utf8'));
+    const result = compareToGoldenFile(output, output);
+    expect(result.match).toBe(true);
+    expect(result.differences).toHaveLength(0);
+  });
+});

--- a/functions/src/__tests__/prompts/templates.test.ts
+++ b/functions/src/__tests__/prompts/templates.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * TDD RED phase — tests for prompt template rendering.
+ * Templates return prompt strings with parameters injected.
+ */
+describe('buildBullCasePrompt', () => {
+  it('injects ticker, companyName, financialData and filingContext into the prompt', async () => {
+    const { buildBullCasePrompt } = await import('../../services/prompts/bullCase.js');
+    const params = {
+      ticker: 'AAPL',
+      companyName: 'Apple Inc.',
+      financialData: 'Revenue: $383B, FCF: $90B, Net Margin: 25%',
+      filingContext: '10-K 2023: Services revenue grew 16% YoY',
+    };
+    const prompt = buildBullCasePrompt(params);
+    expect(prompt).toContain('AAPL');
+    expect(prompt).toContain('Apple Inc.');
+    expect(prompt).toContain('Revenue: $383B');
+    expect(prompt).toContain('10-K 2023: Services revenue grew 16% YoY');
+  });
+
+  it('instructs the model to return JSON with arguments array', async () => {
+    const { buildBullCasePrompt } = await import('../../services/prompts/bullCase.js');
+    const params = {
+      ticker: 'MSFT',
+      companyName: 'Microsoft',
+      financialData: 'Revenue: $211B',
+      filingContext: 'Cloud revenue up 20%',
+    };
+    const prompt = buildBullCasePrompt(params);
+    expect(prompt.toLowerCase()).toContain('json');
+    expect(prompt.toLowerCase()).toContain('arguments');
+  });
+
+  it('requires between 3 and 5 arguments', async () => {
+    const { buildBullCasePrompt } = await import('../../services/prompts/bullCase.js');
+    const params = {
+      ticker: 'NVDA',
+      companyName: 'NVIDIA',
+      financialData: 'Revenue: $60B',
+      filingContext: 'Data center revenue tripled',
+    };
+    const prompt = buildBullCasePrompt(params);
+    // Should mention 3-5 arguments
+    expect(prompt).toMatch(/3.{0,10}5/);
+  });
+
+  it('returns the configured LLM options with temperature 0.7', async () => {
+    const { BULL_CASE_OPTIONS } = await import('../../services/prompts/bullCase.js');
+    expect(BULL_CASE_OPTIONS.temperature).toBe(0.7);
+  });
+});
+
+describe('buildBearCasePrompt', () => {
+  it('injects ticker, companyName, financialData and filingContext into the prompt', async () => {
+    const { buildBearCasePrompt } = await import('../../services/prompts/bearCase.js');
+    const params = {
+      ticker: 'TSLA',
+      companyName: 'Tesla Inc.',
+      financialData: 'Revenue: $96B, Margin: 8%',
+      filingContext: '10-K 2023: Margin compression due to price cuts',
+    };
+    const prompt = buildBearCasePrompt(params);
+    expect(prompt).toContain('TSLA');
+    expect(prompt).toContain('Tesla Inc.');
+    expect(prompt).toContain('Revenue: $96B');
+    expect(prompt).toContain('Margin compression due to price cuts');
+  });
+
+  it('instructs the model to return JSON with riskFactors array', async () => {
+    const { buildBearCasePrompt } = await import('../../services/prompts/bearCase.js');
+    const params = {
+      ticker: 'TSLA',
+      companyName: 'Tesla',
+      financialData: 'Revenue: $96B',
+      filingContext: 'Price cuts hit margins',
+    };
+    const prompt = buildBearCasePrompt(params);
+    expect(prompt.toLowerCase()).toContain('json');
+    expect(prompt.toLowerCase()).toContain('riskfactors');
+  });
+
+  it('returns the configured LLM options with temperature 0.7', async () => {
+    const { BEAR_CASE_OPTIONS } = await import('../../services/prompts/bearCase.js');
+    expect(BEAR_CASE_OPTIONS.temperature).toBe(0.7);
+  });
+});
+
+describe('buildSynthesisPrompt', () => {
+  it('injects bullCaseJson, bearCaseJson and financialData into the prompt', async () => {
+    const { buildSynthesisPrompt } = await import('../../services/prompts/synthesis.js');
+    const params = {
+      bullCaseJson: '{"arguments":[{"title":"Growth"}]}',
+      bearCaseJson: '{"riskFactors":[{"title":"Risk"}]}',
+      financialData: 'P/E: 28, FCF Yield: 3%',
+    };
+    const prompt = buildSynthesisPrompt(params);
+    expect(prompt).toContain('"arguments"');
+    expect(prompt).toContain('"riskFactors"');
+    expect(prompt).toContain('P/E: 28');
+  });
+
+  it('instructs the model to return JSON with keyFactors, recommendation, and disclaimer', async () => {
+    const { buildSynthesisPrompt } = await import('../../services/prompts/synthesis.js');
+    const params = {
+      bullCaseJson: '{}',
+      bearCaseJson: '{}',
+      financialData: 'Revenue: $100B',
+    };
+    const prompt = buildSynthesisPrompt(params);
+    expect(prompt.toLowerCase()).toContain('json');
+    expect(prompt.toLowerCase()).toContain('keyfactors');
+    expect(prompt.toLowerCase()).toContain('recommendation');
+    expect(prompt.toLowerCase()).toContain('disclaimer');
+  });
+
+  it('returns the configured LLM options with temperature 0.3', async () => {
+    const { SYNTHESIS_OPTIONS } = await import('../../services/prompts/synthesis.js');
+    expect(SYNTHESIS_OPTIONS.temperature).toBe(0.3);
+  });
+});

--- a/functions/src/__tests__/prompts/types.test.ts
+++ b/functions/src/__tests__/prompts/types.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * TDD RED phase — tests for DebateOutput types and runtime guards.
+ * These tests will fail until types.ts is implemented.
+ */
+describe('isValidArgument', () => {
+  it('accepts a valid Argument object', async () => {
+    const { isValidArgument } = await import('../../services/prompts/types.js');
+    expect(isValidArgument({ title: 'Revenue growth', detail: 'Strong YoY growth', citation: '10-K p.42' })).toBe(true);
+  });
+
+  it('rejects argument missing required fields', async () => {
+    const { isValidArgument } = await import('../../services/prompts/types.js');
+    expect(isValidArgument({ title: 'No detail' })).toBe(false);
+    expect(isValidArgument({ detail: 'No title', citation: 'x' })).toBe(false);
+    expect(isValidArgument(null)).toBe(false);
+  });
+});
+
+describe('isValidRiskFactor', () => {
+  it('accepts a valid RiskFactor object', async () => {
+    const { isValidRiskFactor } = await import('../../services/prompts/types.js');
+    expect(isValidRiskFactor({ title: 'Competition', detail: 'Market share pressure', dataPoint: 'Share -5% YoY' })).toBe(true);
+  });
+
+  it('rejects risk factor missing required fields', async () => {
+    const { isValidRiskFactor } = await import('../../services/prompts/types.js');
+    expect(isValidRiskFactor({ title: 'x', detail: 'y' })).toBe(false);
+    expect(isValidRiskFactor({})).toBe(false);
+  });
+});
+
+describe('isValidFactor', () => {
+  it('accepts a valid Factor object', async () => {
+    const { isValidFactor } = await import('../../services/prompts/types.js');
+    expect(isValidFactor({ title: 'Valuation', analysis: 'P/E is elevated' })).toBe(true);
+  });
+
+  it('rejects factor missing required fields', async () => {
+    const { isValidFactor } = await import('../../services/prompts/types.js');
+    expect(isValidFactor({ title: 'x' })).toBe(false);
+    expect(isValidFactor({ analysis: 'y' })).toBe(false);
+  });
+});
+
+describe('isValidBullCase', () => {
+  it('accepts a valid BullCase object', async () => {
+    const { isValidBullCase } = await import('../../services/prompts/types.js');
+    const bullCase = {
+      arguments: [{ title: 'Growth', detail: 'Strong revenue', citation: '10-K p.5' }],
+      confidence: 0.75,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(isValidBullCase(bullCase)).toBe(true);
+  });
+
+  it('rejects bull case with confidence outside 0-1 range', async () => {
+    const { isValidBullCase } = await import('../../services/prompts/types.js');
+    const bullCase = {
+      arguments: [{ title: 'Growth', detail: 'Strong', citation: 'p.1' }],
+      confidence: 1.5,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(isValidBullCase(bullCase)).toBe(false);
+  });
+
+  it('rejects bull case with empty arguments array', async () => {
+    const { isValidBullCase } = await import('../../services/prompts/types.js');
+    const bullCase = {
+      arguments: [],
+      confidence: 0.8,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(isValidBullCase(bullCase)).toBe(false);
+  });
+});
+
+describe('isValidBearCase', () => {
+  it('accepts a valid BearCase object', async () => {
+    const { isValidBearCase } = await import('../../services/prompts/types.js');
+    const bearCase = {
+      riskFactors: [{ title: 'Competition', detail: 'Pressure', dataPoint: 'Share -5%' }],
+      confidence: 0.6,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(isValidBearCase(bearCase)).toBe(true);
+  });
+
+  it('rejects bear case with empty riskFactors array', async () => {
+    const { isValidBearCase } = await import('../../services/prompts/types.js');
+    const bearCase = {
+      riskFactors: [],
+      confidence: 0.6,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(isValidBearCase(bearCase)).toBe(false);
+  });
+});
+
+describe('isValidSynthesis', () => {
+  it('accepts a valid Synthesis object', async () => {
+    const { isValidSynthesis } = await import('../../services/prompts/types.js');
+    const synthesis = {
+      keyFactors: [{ title: 'Moat', analysis: 'Strong brand' }],
+      recommendation: 'HOLD',
+      confidence: 0.7,
+      disclaimer: 'Not financial advice.',
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(isValidSynthesis(synthesis)).toBe(true);
+  });
+
+  it('rejects synthesis missing disclaimer', async () => {
+    const { isValidSynthesis } = await import('../../services/prompts/types.js');
+    const synthesis = {
+      keyFactors: [{ title: 'Moat', analysis: 'Strong' }],
+      recommendation: 'BUY',
+      confidence: 0.8,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(isValidSynthesis(synthesis)).toBe(false);
+  });
+});
+
+describe('isValidDebateOutput', () => {
+  it('accepts a complete DebateOutput object', async () => {
+    const { isValidDebateOutput } = await import('../../services/prompts/types.js');
+    const output = {
+      bullCase: {
+        arguments: [{ title: 'Growth', detail: 'Revenue up 20%', citation: '10-K p.5' }],
+        confidence: 0.8,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      bearCase: {
+        riskFactors: [{ title: 'Competition', detail: 'Market pressure', dataPoint: 'Share -5%' }],
+        confidence: 0.6,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      synthesis: {
+        keyFactors: [{ title: 'Valuation', analysis: 'Fairly priced' }],
+        recommendation: 'HOLD',
+        confidence: 0.7,
+        disclaimer: 'Not financial advice.',
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    expect(isValidDebateOutput(output)).toBe(true);
+  });
+
+  it('rejects output missing bearCase', async () => {
+    const { isValidDebateOutput } = await import('../../services/prompts/types.js');
+    const output = {
+      bullCase: {
+        arguments: [{ title: 'Growth', detail: 'Revenue up', citation: 'p.1' }],
+        confidence: 0.8,
+        generatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+    expect(isValidDebateOutput(output)).toBe(false);
+  });
+});

--- a/functions/src/__tests__/prompts/validation.test.ts
+++ b/functions/src/__tests__/prompts/validation.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * TDD RED phase — tests for schema validation and content heuristics.
+ */
+describe('validateBullCase', () => {
+  it('returns valid for a well-formed bull case', async () => {
+    const { validateBullCase } = await import('../../services/prompts/validation.js');
+    const bullCase = {
+      arguments: [
+        { title: 'Revenue growth', detail: 'Apple grew revenue 8% YoY', citation: '10-K FY2023 p.22' },
+        { title: 'Strong moat', detail: 'Ecosystem lock-in', citation: 'Investor Day transcript' },
+      ],
+      confidence: 0.8,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = validateBullCase(bullCase, 'Apple');
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('fails when arguments array is empty', async () => {
+    const { validateBullCase } = await import('../../services/prompts/validation.js');
+    const bullCase = { arguments: [], confidence: 0.8, generatedAt: '2024-01-01T00:00:00.000Z' };
+    const result = validateBullCase(bullCase, 'Apple');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /argument/i.test(e))).toBe(true);
+  });
+
+  it('fails when company name not present in any argument detail', async () => {
+    const { validateBullCase } = await import('../../services/prompts/validation.js');
+    const bullCase = {
+      arguments: [
+        { title: 'Growth', detail: 'Revenue up 20% YoY', citation: 'p.5' },
+      ],
+      confidence: 0.8,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = validateBullCase(bullCase, 'Microsoft');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /company name/i.test(e))).toBe(true);
+  });
+
+  it('fails when confidence is out of 0-1 range', async () => {
+    const { validateBullCase } = await import('../../services/prompts/validation.js');
+    const bullCase = {
+      arguments: [{ title: 'Growth', detail: 'Apple grew strongly', citation: 'p.1' }],
+      confidence: 2.5,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = validateBullCase(bullCase, 'Apple');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /confidence/i.test(e))).toBe(true);
+  });
+});
+
+describe('validateBearCase', () => {
+  it('returns valid for a well-formed bear case', async () => {
+    const { validateBearCase } = await import('../../services/prompts/validation.js');
+    const bearCase = {
+      riskFactors: [
+        { title: 'Competition', detail: 'Tesla faces intense competition from BYD', dataPoint: 'Market share -3% in China' },
+      ],
+      confidence: 0.7,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = validateBearCase(bearCase, 'Tesla');
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('fails when riskFactors array is empty', async () => {
+    const { validateBearCase } = await import('../../services/prompts/validation.js');
+    const bearCase = { riskFactors: [], confidence: 0.5, generatedAt: '2024-01-01T00:00:00.000Z' };
+    const result = validateBearCase(bearCase, 'Tesla');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /risk factor/i.test(e))).toBe(true);
+  });
+
+  it('fails when company name not present in any risk factor detail', async () => {
+    const { validateBearCase } = await import('../../services/prompts/validation.js');
+    const bearCase = {
+      riskFactors: [
+        { title: 'Risk', detail: 'Intense competition in EV space', dataPoint: 'Share -3%' },
+      ],
+      confidence: 0.5,
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = validateBearCase(bearCase, 'Tesla');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /company name/i.test(e))).toBe(true);
+  });
+});
+
+describe('validateSynthesis', () => {
+  it('returns valid for a well-formed synthesis', async () => {
+    const { validateSynthesis } = await import('../../services/prompts/validation.js');
+    const synthesis = {
+      keyFactors: [{ title: 'Valuation', analysis: 'Apple trades at a premium but justified by moat' }],
+      recommendation: 'HOLD',
+      confidence: 0.65,
+      disclaimer: 'This is not financial advice. Do your own research.',
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = validateSynthesis(synthesis);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('fails when disclaimer is missing or empty', async () => {
+    const { validateSynthesis } = await import('../../services/prompts/validation.js');
+    const synthesis = {
+      keyFactors: [{ title: 'Valuation', analysis: 'Premium valuation' }],
+      recommendation: 'BUY',
+      confidence: 0.8,
+      disclaimer: '',
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = validateSynthesis(synthesis);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /disclaimer/i.test(e))).toBe(true);
+  });
+
+  it('fails when keyFactors array is empty', async () => {
+    const { validateSynthesis } = await import('../../services/prompts/validation.js');
+    const synthesis = {
+      keyFactors: [],
+      recommendation: 'BUY',
+      confidence: 0.8,
+      disclaimer: 'Not financial advice.',
+      generatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = validateSynthesis(synthesis);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /key factor/i.test(e))).toBe(true);
+  });
+});
+
+describe('validateDebateArguments are distinct', () => {
+  it('fails when bull and bear arguments have duplicate titles', async () => {
+    const { validateDebateArgumentsAreDistinct } = await import('../../services/prompts/validation.js');
+    const bullTitles = ['Revenue growth', 'Strong moat', 'Global reach'];
+    const bearTitles = ['Revenue growth', 'Debt concerns', 'Regulatory risk'];
+    const result = validateDebateArgumentsAreDistinct(bullTitles, bearTitles);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => /duplicate/i.test(e))).toBe(true);
+  });
+
+  it('passes when bull and bear arguments have no overlapping titles', async () => {
+    const { validateDebateArgumentsAreDistinct } = await import('../../services/prompts/validation.js');
+    const bullTitles = ['Revenue growth', 'Strong moat'];
+    const bearTitles = ['Competition risk', 'Valuation concerns'];
+    const result = validateDebateArgumentsAreDistinct(bullTitles, bearTitles);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/functions/src/services/prompts/bearCase.ts
+++ b/functions/src/services/prompts/bearCase.ts
@@ -1,0 +1,54 @@
+import type { LLMOptions } from '../llm/types.js';
+
+export interface BearCasePromptParams {
+  ticker: string;
+  companyName: string;
+  financialData: string;
+  filingContext: string;
+}
+
+/** LLM options for bear case generation. Temperature 0.7 encourages diverse risk identification. */
+export const BEAR_CASE_OPTIONS: LLMOptions = {
+  maxTokens: 1500,
+  temperature: 0.7,
+};
+
+/**
+ * Builds the bear case prompt string.
+ * The LLM service calls this output — this function only renders the text.
+ */
+export function buildBearCasePrompt(params: BearCasePromptParams): string {
+  const { ticker, companyName, financialData, filingContext } = params;
+  return `You are a skeptical equity analyst trained to stress-test investment theses and identify risks.
+
+Your task: generate a PESSIMISTIC investment thesis (bear case) for ${companyName} (${ticker}).
+
+## Financial Data
+${financialData}
+
+## SEC Filing Context
+${filingContext}
+
+## Instructions
+- Identify 3-5 of the most significant risk factors and bear case arguments from the data above.
+- Each risk factor must reference specific data points, metrics, or filing details.
+- Focus on valuation risks, competitive threats, margin pressure, balance sheet concerns, and macro headwinds.
+- Mention "${companyName}" explicitly in each risk factor detail to ground the analysis.
+
+## Output Format
+Respond ONLY with valid JSON — no markdown, no commentary. Structure:
+
+{
+  "riskFactors": [
+    {
+      "title": "short title of the risk (max 8 words)",
+      "detail": "2-3 sentence explanation of the risk, mentioning ${companyName}",
+      "dataPoint": "specific metric or data point supporting this risk (e.g., 'Gross margin declined from 43% to 38% YoY')"
+    }
+  ],
+  "confidence": 0.0,
+  "generatedAt": "${new Date().toISOString()}"
+}
+
+Set "confidence" to a float between 0.0 and 1.0 reflecting how compelling the bear case is based on the evidence provided.`;
+}

--- a/functions/src/services/prompts/bullCase.ts
+++ b/functions/src/services/prompts/bullCase.ts
@@ -1,0 +1,54 @@
+import type { LLMOptions } from '../llm/types.js';
+
+export interface BullCasePromptParams {
+  ticker: string;
+  companyName: string;
+  financialData: string;
+  filingContext: string;
+}
+
+/** LLM options for bull case generation. Temperature 0.7 encourages diverse reasoning. */
+export const BULL_CASE_OPTIONS: LLMOptions = {
+  maxTokens: 1500,
+  temperature: 0.7,
+};
+
+/**
+ * Builds the bull case prompt string.
+ * The LLM service calls this output — this function only renders the text.
+ */
+export function buildBullCasePrompt(params: BullCasePromptParams): string {
+  const { ticker, companyName, financialData, filingContext } = params;
+  return `You are an experienced equity analyst specialising in value investing, trained on the Feroldi and Buffett methodologies.
+
+Your task: generate an OPTIMISTIC investment thesis (bull case) for ${companyName} (${ticker}).
+
+## Financial Data
+${financialData}
+
+## SEC Filing Context
+${filingContext}
+
+## Instructions
+- Identify 3-5 of the strongest bull case arguments grounded in the financial data and SEC filings above.
+- Each argument must reference specific numbers, metrics, or filing citations.
+- Focus on durable competitive advantages, revenue quality, free cash flow generation, and management execution.
+- Mention "${companyName}" explicitly in each argument detail to ground the analysis.
+
+## Output Format
+Respond ONLY with valid JSON — no markdown, no commentary. Structure:
+
+{
+  "arguments": [
+    {
+      "title": "short title of the argument (max 8 words)",
+      "detail": "2-3 sentence explanation grounded in the data, mentioning ${companyName}",
+      "citation": "source reference (e.g., '10-K FY2023 p.42' or 'Q3 2023 Earnings Call')"
+    }
+  ],
+  "confidence": 0.0,
+  "generatedAt": "${new Date().toISOString()}"
+}
+
+Set "confidence" to a float between 0.0 and 1.0 reflecting how compelling the bull case is based on the evidence provided.`;
+}

--- a/functions/src/services/prompts/evaluation.ts
+++ b/functions/src/services/prompts/evaluation.ts
@@ -1,0 +1,105 @@
+import type { DebateOutput } from './types.js';
+import {
+  validateBullCase,
+  validateBearCase,
+  validateSynthesis,
+  validateDebateArgumentsAreDistinct,
+} from './validation.js';
+
+export interface EvaluationResult {
+  passed: boolean;
+  errors: string[];
+}
+
+export interface GoldenFileComparisonResult {
+  match: boolean;
+  differences: string[];
+}
+
+/**
+ * Evaluates a DebateOutput for schema validity and content quality.
+ * Can be invoked manually or in CI as a regression guard.
+ *
+ * @param output - The debate output to evaluate (may be raw unknown from LLM)
+ * @param companyName - Company name used for content heuristic checks
+ */
+export function evaluateDebateOutput(output: unknown, companyName: string): EvaluationResult {
+  const errors: string[] = [];
+
+  if (typeof output !== 'object' || output === null) {
+    return { passed: false, errors: ['Output must be a non-null object'] };
+  }
+
+  const o = output as Record<string, unknown>;
+
+  // --- Bull case validation ---
+  const bullResult = validateBullCase(o['bullCase'], companyName);
+  errors.push(...bullResult.errors);
+
+  // --- Bear case validation ---
+  const bearResult = validateBearCase(o['bearCase'], companyName);
+  errors.push(...bearResult.errors);
+
+  // --- Synthesis validation ---
+  const synthResult = validateSynthesis(o['synthesis']);
+  errors.push(...synthResult.errors);
+
+  // --- Cross-case: distinct arguments ---
+  if (bullResult.valid && bearResult.valid) {
+    const bullCase = o['bullCase'] as { arguments: Array<{ title: string }> };
+    const bearCase = o['bearCase'] as { riskFactors: Array<{ title: string }> };
+    const bullTitles = bullCase.arguments.map((a) => a.title);
+    const bearTitles = bearCase.riskFactors.map((r) => r.title);
+    const distinctResult = validateDebateArgumentsAreDistinct(bullTitles, bearTitles);
+    errors.push(...distinctResult.errors);
+  }
+
+  return { passed: errors.length === 0, errors };
+}
+
+/**
+ * Compares a DebateOutput against a golden file for structural regression testing.
+ * Checks array lengths and key field presence — not exact string matching.
+ */
+export function compareToGoldenFile(
+  actual: DebateOutput,
+  golden: DebateOutput
+): GoldenFileComparisonResult {
+  const differences: string[] = [];
+
+  if (actual.bullCase.arguments.length !== golden.bullCase.arguments.length) {
+    differences.push(
+      `Bull case argument count mismatch: expected ${golden.bullCase.arguments.length}, got ${actual.bullCase.arguments.length}`
+    );
+  }
+
+  if (actual.bearCase.riskFactors.length !== golden.bearCase.riskFactors.length) {
+    differences.push(
+      `Bear case risk factor count mismatch: expected ${golden.bearCase.riskFactors.length}, got ${actual.bearCase.riskFactors.length}`
+    );
+  }
+
+  if (actual.synthesis.keyFactors.length !== golden.synthesis.keyFactors.length) {
+    differences.push(
+      `Synthesis key factor count mismatch: expected ${golden.synthesis.keyFactors.length}, got ${actual.synthesis.keyFactors.length}`
+    );
+  }
+
+  // Check structural field presence in each bull argument
+  for (let i = 0; i < actual.bullCase.arguments.length; i++) {
+    const arg = actual.bullCase.arguments[i];
+    if (!arg.title || !arg.detail || !arg.citation) {
+      differences.push(`Bull case argument[${i}] is missing title, detail, or citation`);
+    }
+  }
+
+  // Check structural field presence in each bear risk factor
+  for (let i = 0; i < actual.bearCase.riskFactors.length; i++) {
+    const rf = actual.bearCase.riskFactors[i];
+    if (!rf.title || !rf.detail || !rf.dataPoint) {
+      differences.push(`Bear case riskFactor[${i}] is missing title, detail, or dataPoint`);
+    }
+  }
+
+  return { match: differences.length === 0, differences };
+}

--- a/functions/src/services/prompts/goldenFiles/AAPL.json
+++ b/functions/src/services/prompts/goldenFiles/AAPL.json
@@ -1,0 +1,77 @@
+{
+  "ticker": "AAPL",
+  "companyName": "Apple Inc.",
+  "generatedAt": "2024-01-01T00:00:00.000Z",
+  "bullCase": {
+    "arguments": [
+      {
+        "title": "Services revenue flywheel",
+        "detail": "Apple Inc. has grown its Services segment to $85.2B in annual revenue, representing 22% of total revenue and delivering gross margins above 70%. This high-margin, recurring revenue stream significantly improves the quality of Apple's earnings and reduces cyclical hardware dependency.",
+        "citation": "10-K FY2023, p. 22 — Segment Results"
+      },
+      {
+        "title": "Exceptional free cash flow generation",
+        "detail": "Apple Inc. generated $99.6B in operating cash flow in FY2023, translating to $89.9B in free cash flow. This extraordinary cash generation enables Apple to return capital to shareholders through buybacks ($77.6B in FY2023) and dividends while maintaining strategic flexibility.",
+        "citation": "10-K FY2023, Consolidated Statements of Cash Flows, p. 44"
+      },
+      {
+        "title": "Ecosystem lock-in and switching costs",
+        "detail": "Apple Inc.'s tightly integrated hardware-software-services ecosystem creates substantial switching costs for the 2B+ active devices in its install base. iCloud, App Store, iMessage, and Apple Pay create cross-product dependencies that significantly reduce churn and support premium pricing power.",
+        "citation": "10-K FY2023, Business Overview, p. 2 — Active Devices"
+      },
+      {
+        "title": "Consistent capital return program",
+        "detail": "Apple Inc. has returned over $600B to shareholders since initiating its capital return program. The combination of meaningful dividend growth and aggressive share repurchases has consistently enhanced per-share metrics and reflects management's confidence in long-term cash flow durability.",
+        "citation": "10-K FY2023, Liquidity and Capital Resources, p. 30"
+      }
+    ],
+    "confidence": 0.82,
+    "generatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  "bearCase": {
+    "riskFactors": [
+      {
+        "title": "China revenue concentration risk",
+        "detail": "Apple Inc. derives approximately 19% of total revenue from Greater China, creating significant geopolitical and regulatory exposure. Escalating US-China tensions, potential retaliatory measures, and competition from domestic brands such as Huawei and Xiaomi threaten this critical revenue stream.",
+        "dataPoint": "China revenue $72.6B (FY2023), ~19% of total revenue; Huawei smartphone shipments rebounded +40% YoY in 2023"
+      },
+      {
+        "title": "iPhone revenue stagnation",
+        "detail": "Apple Inc.'s iPhone segment, representing 52% of revenue, saw revenue decline 2.3% YoY in FY2023. With smartphone penetration in developed markets nearing saturation, sustaining iPhone unit growth requires either price increases (risking volume) or share gains in price-sensitive emerging markets.",
+        "dataPoint": "iPhone revenue $200.6B FY2023 vs. $205.5B FY2022; global smartphone market -3.2% in 2023"
+      },
+      {
+        "title": "Valuation premium limits upside",
+        "detail": "Apple Inc. trades at approximately 28x forward earnings and 25x EV/FCF, a significant premium to the S&P 500 average. For this premium to be sustained, Apple must continue delivering mid-single digit revenue growth alongside expanding margins — a difficult bar in a mature hardware cycle.",
+        "dataPoint": "P/E ~28x (Jan 2024) vs. S&P 500 ~21x; 5-year revenue CAGR ~8% but decelerating to ~2% in FY2023"
+      },
+      {
+        "title": "Regulatory and antitrust headwinds",
+        "detail": "Apple Inc. faces mounting regulatory scrutiny over App Store practices in the EU (Digital Markets Act), US DOJ antitrust investigation, and potential changes to Google's $18–20B annual search traffic agreement. Any adverse ruling could materially impact the high-margin Services segment.",
+        "dataPoint": "Google TAC payment estimated at $18-20B annually; EU DMA mandates iOS sideloading from March 2024"
+      }
+    ],
+    "confidence": 0.71,
+    "generatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  "synthesis": {
+    "keyFactors": [
+      {
+        "title": "Services growth sustainability",
+        "analysis": "The bull case hinges on Services continuing to expand both revenue and margins. If Apple can grow Services to 30%+ of revenue, the margin mix shift significantly re-rates the business. The bear risk is that regulatory actions (DMA, DOJ) structurally impair App Store economics."
+      },
+      {
+        "title": "China exposure resolution",
+        "analysis": "China is the single largest swing factor — representing both a growth opportunity and a concentration risk. Investors should monitor Huawei's premium smartphone recovery and any US trade restrictions on Apple's supply chain. A China revenue decline of >15% would weigh significantly on the thesis."
+      },
+      {
+        "title": "Valuation vs. growth rate alignment",
+        "analysis": "At 28x forward P/E, Apple requires consistent mid-single digit revenue growth to justify its premium. The bear case is not that Apple is a bad business — it is that the price already reflects the quality. Patient investors may find better entry points during broader market corrections."
+      }
+    ],
+    "recommendation": "HOLD",
+    "confidence": 0.72,
+    "disclaimer": "This analysis is for informational and educational purposes only and does not constitute financial advice, an offer to buy or sell securities, or investment recommendations. Past performance is not indicative of future results. All investments carry risk, including the potential loss of principal. Always conduct your own due diligence and consult a qualified financial advisor before making investment decisions.",
+    "generatedAt": "2024-01-01T00:00:00.000Z"
+  }
+}

--- a/functions/src/services/prompts/index.ts
+++ b/functions/src/services/prompts/index.ts
@@ -1,0 +1,38 @@
+export type {
+  Argument,
+  RiskFactor,
+  Factor,
+  BullCase,
+  BearCase,
+  Synthesis,
+  DebateOutput,
+} from './types.js';
+export {
+  isValidArgument,
+  isValidRiskFactor,
+  isValidFactor,
+  isValidBullCase,
+  isValidBearCase,
+  isValidSynthesis,
+  isValidDebateOutput,
+} from './types.js';
+
+export type { BullCasePromptParams } from './bullCase.js';
+export { buildBullCasePrompt, BULL_CASE_OPTIONS } from './bullCase.js';
+
+export type { BearCasePromptParams } from './bearCase.js';
+export { buildBearCasePrompt, BEAR_CASE_OPTIONS } from './bearCase.js';
+
+export type { SynthesisPromptParams } from './synthesis.js';
+export { buildSynthesisPrompt, SYNTHESIS_OPTIONS } from './synthesis.js';
+
+export type { ValidationResult } from './validation.js';
+export {
+  validateBullCase,
+  validateBearCase,
+  validateSynthesis,
+  validateDebateArgumentsAreDistinct,
+} from './validation.js';
+
+export type { EvaluationResult, GoldenFileComparisonResult } from './evaluation.js';
+export { evaluateDebateOutput, compareToGoldenFile } from './evaluation.js';

--- a/functions/src/services/prompts/synthesis.ts
+++ b/functions/src/services/prompts/synthesis.ts
@@ -1,0 +1,57 @@
+import type { LLMOptions } from '../llm/types.js';
+
+export interface SynthesisPromptParams {
+  bullCaseJson: string;
+  bearCaseJson: string;
+  financialData: string;
+}
+
+/** LLM options for synthesis generation. Lower temperature 0.3 for more measured, factual output. */
+export const SYNTHESIS_OPTIONS: LLMOptions = {
+  maxTokens: 1200,
+  temperature: 0.3,
+};
+
+/**
+ * Builds the synthesis prompt string that weighs bull and bear cases.
+ * The LLM service calls this output — this function only renders the text.
+ */
+export function buildSynthesisPrompt(params: SynthesisPromptParams): string {
+  const { bullCaseJson, bearCaseJson, financialData } = params;
+  return `You are a balanced investment analyst synthesising competing viewpoints to help investors make informed decisions.
+
+You have received both a bull case and a bear case for a company. Your task is to weigh both sides and produce a balanced synthesis.
+
+## Bull Case
+${bullCaseJson}
+
+## Bear Case
+${bearCaseJson}
+
+## Financial Data
+${financialData}
+
+## Instructions
+- Identify 2-4 key decision factors that will determine whether the bull or bear case plays out.
+- Provide a balanced recommendation: BUY, HOLD, or WATCH (do not use SELL — this is a long-term framework).
+- Be specific about what an investor should monitor.
+- Always include an investment disclaimer.
+
+## Output Format
+Respond ONLY with valid JSON — no markdown, no commentary. Structure:
+
+{
+  "keyFactors": [
+    {
+      "title": "short title of the factor (max 8 words)",
+      "analysis": "2-3 sentence balanced analysis of this factor"
+    }
+  ],
+  "recommendation": "BUY | HOLD | WATCH",
+  "confidence": 0.0,
+  "disclaimer": "This analysis is for informational purposes only and does not constitute financial advice. Past performance is not indicative of future results. Always conduct your own due diligence before making investment decisions.",
+  "generatedAt": "${new Date().toISOString()}"
+}
+
+Set "confidence" to a float between 0.0 and 1.0 reflecting your conviction in the recommendation given the evidence.`;
+}

--- a/functions/src/services/prompts/types.ts
+++ b/functions/src/services/prompts/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Output types for AI Bull vs Bear Debate generation.
+ */
+
+export interface Argument {
+  title: string;
+  detail: string;
+  citation: string;
+}
+
+export interface RiskFactor {
+  title: string;
+  detail: string;
+  dataPoint: string;
+}
+
+export interface Factor {
+  title: string;
+  analysis: string;
+}
+
+export interface BullCase {
+  arguments: Argument[];
+  confidence: number;
+  generatedAt: string;
+}
+
+export interface BearCase {
+  riskFactors: RiskFactor[];
+  confidence: number;
+  generatedAt: string;
+}
+
+export interface Synthesis {
+  keyFactors: Factor[];
+  recommendation: string;
+  confidence: number;
+  disclaimer: string;
+  generatedAt: string;
+}
+
+export interface DebateOutput {
+  bullCase: BullCase;
+  bearCase: BearCase;
+  synthesis: Synthesis;
+}
+
+// ─── Runtime guards ───────────────────────────────────────────────────────────
+
+function isObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === 'object' && val !== null && !Array.isArray(val);
+}
+
+export function isValidArgument(val: unknown): val is Argument {
+  if (!isObject(val)) return false;
+  return (
+    typeof val['title'] === 'string' &&
+    typeof val['detail'] === 'string' &&
+    typeof val['citation'] === 'string'
+  );
+}
+
+export function isValidRiskFactor(val: unknown): val is RiskFactor {
+  if (!isObject(val)) return false;
+  return (
+    typeof val['title'] === 'string' &&
+    typeof val['detail'] === 'string' &&
+    typeof val['dataPoint'] === 'string'
+  );
+}
+
+export function isValidFactor(val: unknown): val is Factor {
+  if (!isObject(val)) return false;
+  return (
+    typeof val['title'] === 'string' &&
+    typeof val['analysis'] === 'string'
+  );
+}
+
+function isConfidenceInRange(val: unknown): val is number {
+  return typeof val === 'number' && val >= 0 && val <= 1;
+}
+
+export function isValidBullCase(val: unknown): val is BullCase {
+  if (!isObject(val)) return false;
+  if (!Array.isArray(val['arguments']) || val['arguments'].length === 0) return false;
+  if (!val['arguments'].every(isValidArgument)) return false;
+  if (!isConfidenceInRange(val['confidence'])) return false;
+  if (typeof val['generatedAt'] !== 'string') return false;
+  return true;
+}
+
+export function isValidBearCase(val: unknown): val is BearCase {
+  if (!isObject(val)) return false;
+  if (!Array.isArray(val['riskFactors']) || val['riskFactors'].length === 0) return false;
+  if (!val['riskFactors'].every(isValidRiskFactor)) return false;
+  if (!isConfidenceInRange(val['confidence'])) return false;
+  if (typeof val['generatedAt'] !== 'string') return false;
+  return true;
+}
+
+export function isValidSynthesis(val: unknown): val is Synthesis {
+  if (!isObject(val)) return false;
+  if (!Array.isArray(val['keyFactors']) || val['keyFactors'].length === 0) return false;
+  if (!val['keyFactors'].every(isValidFactor)) return false;
+  if (typeof val['recommendation'] !== 'string') return false;
+  if (!isConfidenceInRange(val['confidence'])) return false;
+  if (typeof val['disclaimer'] !== 'string') return false;
+  if (typeof val['generatedAt'] !== 'string') return false;
+  return true;
+}
+
+export function isValidDebateOutput(val: unknown): val is DebateOutput {
+  if (!isObject(val)) return false;
+  return (
+    isValidBullCase(val['bullCase']) &&
+    isValidBearCase(val['bearCase']) &&
+    isValidSynthesis(val['synthesis'])
+  );
+}

--- a/functions/src/services/prompts/validation.ts
+++ b/functions/src/services/prompts/validation.ts
@@ -1,0 +1,124 @@
+import type { BullCase, BearCase, Synthesis } from './types.js';
+import { isValidBullCase, isValidBearCase, isValidSynthesis } from './types.js';
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Checks whether the company name (case-insensitive) appears in at least one
+ * argument detail or title, ensuring the output is grounded in the company.
+ */
+function companyNamePresent(texts: string[], companyName: string): boolean {
+  const lower = companyName.toLowerCase();
+  return texts.some((t) => t.toLowerCase().includes(lower));
+}
+
+export function validateBullCase(val: unknown, companyName: string): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isValidBullCase(val)) {
+    if (typeof val !== 'object' || val === null) {
+      errors.push('Bull case must be an object');
+      return { valid: false, errors };
+    }
+    const o = val as Record<string, unknown>;
+    if (!Array.isArray(o['arguments']) || o['arguments'].length === 0) {
+      errors.push('Bull case must have at least one argument');
+    }
+    const confidence = o['confidence'];
+    if (typeof confidence !== 'number' || confidence < 0 || confidence > 1) {
+      errors.push('Bull case confidence must be a number between 0 and 1');
+    }
+    if (errors.length === 0) errors.push('Bull case has invalid structure');
+    return { valid: false, errors };
+  }
+
+  // Content heuristics
+  const texts = val.arguments.flatMap((a) => [a.title, a.detail]);
+  if (!companyNamePresent(texts, companyName)) {
+    errors.push(`Company name "${companyName}" not present in bull case arguments — output may not be grounded`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateBearCase(val: unknown, companyName: string): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isValidBearCase(val)) {
+    if (typeof val !== 'object' || val === null) {
+      errors.push('Bear case must be an object');
+      return { valid: false, errors };
+    }
+    const o = val as Record<string, unknown>;
+    if (!Array.isArray(o['riskFactors']) || o['riskFactors'].length === 0) {
+      errors.push('Bear case must have at least one risk factor');
+    }
+    const confidence = o['confidence'];
+    if (typeof confidence !== 'number' || confidence < 0 || confidence > 1) {
+      errors.push('Bear case confidence must be a number between 0 and 1');
+    }
+    if (errors.length === 0) errors.push('Bear case has invalid structure');
+    return { valid: false, errors };
+  }
+
+  // Content heuristics
+  const texts = val.riskFactors.flatMap((r) => [r.title, r.detail]);
+  if (!companyNamePresent(texts, companyName)) {
+    errors.push(`Company name "${companyName}" not present in bear case risk factors — output may not be grounded`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateSynthesis(val: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isValidSynthesis(val)) {
+    if (typeof val !== 'object' || val === null) {
+      errors.push('Synthesis must be an object');
+      return { valid: false, errors };
+    }
+    const o = val as Record<string, unknown>;
+    if (!Array.isArray(o['keyFactors']) || o['keyFactors'].length === 0) {
+      errors.push('Synthesis must have at least one key factor');
+    }
+    if (typeof o['disclaimer'] !== 'string' || (o['disclaimer'] as string).trim() === '') {
+      errors.push('Synthesis must include a non-empty disclaimer');
+    }
+    if (errors.length === 0) errors.push('Synthesis has invalid structure');
+    return { valid: false, errors };
+  }
+
+  // Content heuristics — disclaimer must be non-empty (already enforced by isValidSynthesis
+  // but double-check the trimmed value)
+  if (val.disclaimer.trim() === '') {
+    errors.push('Synthesis disclaimer must not be blank');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateDebateArgumentsAreDistinct(
+  bullTitles: string[],
+  bearTitles: string[]
+): ValidationResult {
+  const errors: string[] = [];
+
+  const bullLower = bullTitles.map((t) => t.toLowerCase());
+  const bearLower = bearTitles.map((t) => t.toLowerCase());
+
+  const duplicates = bullLower.filter((t) => bearLower.includes(t));
+  if (duplicates.length > 0) {
+    errors.push(
+      `Duplicate argument titles found in bull and bear cases: "${duplicates.join('", "')}". Arguments should be distinct.`
+    );
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Convenience — validates a BullCase. */
+export { BullCase, BearCase, Synthesis };


### PR DESCRIPTION
Closes #150

Part of Epic #143 — AI Bull vs Bear Debate Full Stack (v2.0)

## Summary

Implements the prompt templates for all three debate agents (Bull, Bear, Synthesis) and an evaluation harness for testing prompt quality and output consistency.

### Implementation Details

- **8 source files:** types, bullCase, bearCase, synthesis, validation, evaluation, index, AAPL golden file
- **5 test files** with 48 tests, all passing
- **TypeScript clean:** `tsc --noEmit` = 0 errors
- **Code review:** PASS (0 critical, 0 high, 0 medium, 1 low)

## Checklist

- [x] Bull case prompt (3-5 arguments, SEC citations)
- [x] Bear case prompt (3-5 risk factors, data points)
- [x] Synthesis prompt (weighted analysis, confidence, disclaimer)
- [x] Feroldi/Buffett methodology framing
- [x] Parameterized prompts
- [x] Output schema defined (DebateOutput)
- [x] Schema validation + content heuristic tests
- [x] Evaluation harness (CI-runnable)
- [x] Golden file for AAPL
- [x] 48 tests passing