### PR TITLE
fix: SEC CORS proxy via Cloud Functions (#190)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,18 @@ VITE_FIREBASE_APP_ID=your-app-id
 # VITE_USE_FIREBASE_EMULATOR=true
 
 # SEC EDGAR API Configuration
+# In production these MUST be set (or VITE_FUNCTIONS_BASE_URL set) to avoid CORS.
+# The secTickers and secCompanyFacts Cloud Functions proxy SEC endpoints server-side.
+#
+# Option A — set the Cloud Functions base URL (recommended):
+#   VITE_FUNCTIONS_BASE_URL=https://us-central1-<project-id>.cloudfunctions.net
+#
+# Staging:    https://us-central1-edgar-value-miner-staging.cloudfunctions.net
+# Production: https://us-central1-edgar-value-miner.cloudfunctions.net
+VITE_FUNCTIONS_BASE_URL=https://us-central1-edgar-value-miner.cloudfunctions.net
+# Optional override for the tickers proxy (takes precedence over VITE_FUNCTIONS_BASE_URL):
+# VITE_SEC_TICKERS_PROXY_URL=https://us-central1-edgar-value-miner.cloudfunctions.net/secTickers
+# User-Agent string sent to SEC EDGAR (required by SEC fair-access policy).
 VITE_SEC_USER_AGENT=getedgar (admincontact@getedgar.com)
 
 # Financial Modeling Prep (FMP) API Configuration

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'e2e']),
+  globalIgnores(['dist', 'e2e', 'functions/lib', 'functions/node_modules']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "edgar-value-miner-functions",
+  "description": "Firebase Cloud Functions for EDGAR Value Miner",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "serve": "npm run build && firebase emulators:start --only auth,firestore,functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "engines": {
+    "node": "20"
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
+    "firebase-admin": "^13.0.0",
+    "firebase-functions": "^6.0.0"
+  },
+  "devDependencies": {
+    "@firebase/rules-unit-testing": "^4.0.1",
+    "@types/node": "^20.0.0",
+    "firebase-functions-test": "^3.4.0",
+    "firebase-tools": "^14.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
+  },
+  "private": true
+}

--- a/functions/src/__tests__/secProxy.test.ts
+++ b/functions/src/__tests__/secProxy.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// ---------------------------------------------------------------------------
+// Declare mockGet with vi.hoisted so it is available when vi.mock factories run
+// (vi.mock calls are hoisted to the top of the file by Vitest's transformer).
+// ---------------------------------------------------------------------------
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+
+// ---------------------------------------------------------------------------
+// Mock firebase-functions before any imports that pull it in
+// ---------------------------------------------------------------------------
+vi.mock('firebase-functions', () => ({
+  default: {},
+  https: { onRequest: vi.fn() },
+  logger: { error: vi.fn(), info: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the Node.js https module to avoid real network calls.
+// ---------------------------------------------------------------------------
+vi.mock('https', () => ({
+  default: { get: mockGet },
+  get: mockGet,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock zlib
+// ---------------------------------------------------------------------------
+vi.mock('zlib', () => ({
+  default: {},
+  createGunzip: vi.fn(),
+  createInflate: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers to build mock req/res objects
+// ---------------------------------------------------------------------------
+function makeReq(method = 'GET', query: Record<string, string> = {}): {
+  method: string;
+  query: Record<string, string>;
+} {
+  return { method, query };
+}
+
+type MockRes = {
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string>;
+  status: (code: number) => MockRes;
+  json: (body: unknown) => MockRes;
+  send: (body: unknown) => MockRes;
+  set: (key: string, value: string) => MockRes;
+};
+
+function makeRes(): MockRes {
+  const res: MockRes = {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    send(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    set(key: string, value: string) {
+      this.headers[key] = value;
+      return this;
+    },
+  };
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers to simulate SEC HTTP responses via the mockGet stub
+// ---------------------------------------------------------------------------
+type MockIncomingMessage = EventEmitter & {
+  statusCode: number;
+  headers: Record<string, string>;
+  resume?: () => void;
+};
+
+function mockSecSuccess(payload: unknown): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockGet.mockImplementationOnce((_url: any, _opts: any, cb: (res: MockIncomingMessage) => void) => {
+    const body = JSON.stringify(payload);
+    const resEmitter = new EventEmitter() as MockIncomingMessage;
+    resEmitter.statusCode = 200;
+    resEmitter.headers = {};
+
+    process.nextTick(() => {
+      cb(resEmitter);
+      resEmitter.emit('data', Buffer.from(body));
+      resEmitter.emit('end');
+    });
+
+    const reqEmitter = new EventEmitter();
+    return reqEmitter;
+  });
+}
+
+function mockSecError(statusCode: number): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockGet.mockImplementationOnce((_url: any, _opts: any, cb: (res: MockIncomingMessage) => void) => {
+    const resEmitter = new EventEmitter() as MockIncomingMessage;
+    resEmitter.statusCode = statusCode;
+    resEmitter.headers = {};
+    resEmitter.resume = vi.fn();
+
+    process.nextTick(() => cb(resEmitter));
+
+    return new EventEmitter();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Import handlers AFTER mocks are in place
+// ---------------------------------------------------------------------------
+import { secTickersHandler, secCompanyFactsHandler } from '../functions/secProxy.js';
+
+// ---------------------------------------------------------------------------
+// Tests: secTickersHandler
+// ---------------------------------------------------------------------------
+describe('secTickersHandler', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('returns 405 for non-GET methods', async () => {
+    const req = makeReq('POST');
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secTickersHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toMatchObject({ error: 'Method Not Allowed' });
+  });
+
+  it('responds to OPTIONS preflight with 204', async () => {
+    const req = makeReq('OPTIONS');
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secTickersHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('sets CORS headers on every response', async () => {
+    const req = makeReq('OPTIONS');
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secTickersHandler(req as any, res as any);
+
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+
+  it('returns 200 with SEC tickers data on success', async () => {
+    const payload = { '0': { cik_str: '320193', ticker: 'AAPL', title: 'Apple Inc.' } };
+    mockSecSuccess(payload);
+
+    const req = makeReq('GET');
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secTickersHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(payload);
+  });
+
+  it('sets Cache-Control header for 24 hours on success', async () => {
+    const payload = { '0': { cik_str: '320193', ticker: 'AAPL', title: 'Apple Inc.' } };
+    mockSecSuccess(payload);
+
+    const req = makeReq('GET');
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secTickersHandler(req as any, res as any);
+
+    expect(res.headers['Cache-Control']).toContain('max-age=86400');
+  });
+
+  it('returns 502 when SEC API returns an error status', async () => {
+    mockSecError(503);
+
+    const req = makeReq('GET');
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secTickersHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toMatchObject({ error: expect.stringContaining('Failed to fetch') });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: secCompanyFactsHandler
+// ---------------------------------------------------------------------------
+describe('secCompanyFactsHandler', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('returns 400 when cik query param is missing', async () => {
+    const req = makeReq('GET', {});
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.stringContaining('cik') });
+  });
+
+  it('returns 400 when cik is not numeric', async () => {
+    const req = makeReq('GET', { cik: 'AAPL' });
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 405 for non-GET methods', async () => {
+    const req = makeReq('POST', { cik: '320193' });
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('responds to OPTIONS preflight with 204', async () => {
+    const req = makeReq('OPTIONS', {});
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('pads CIK to 10 digits and fetches correct URL', async () => {
+    const payload = { facts: {}, cik: 320193 };
+    mockSecSuccess(payload);
+
+    const req = makeReq('GET', { cik: '320193' });
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockGet).toHaveBeenCalledOnce();
+    const calledUrl = mockGet.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('CIK0000320193.json');
+  });
+
+  it('returns 200 with company facts data on success', async () => {
+    const payload = { facts: { 'us-gaap': {} }, cik: 320193 };
+    mockSecSuccess(payload);
+
+    const req = makeReq('GET', { cik: '320193' });
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(payload);
+  });
+
+  it('sets Cache-Control header for 24 hours on success', async () => {
+    const payload = { facts: {}, cik: 320193 };
+    mockSecSuccess(payload);
+
+    const req = makeReq('GET', { cik: '320193' });
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.headers['Cache-Control']).toContain('max-age=86400');
+  });
+
+  it('returns 404 when SEC returns 404 for unknown CIK', async () => {
+    mockSecError(404);
+
+    const req = makeReq('GET', { cik: '9999999999' });
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toMatchObject({ error: expect.stringContaining('not found') });
+  });
+
+  it('returns 502 when SEC returns a server error', async () => {
+    mockSecError(503);
+
+    const req = makeReq('GET', { cik: '320193' });
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(502);
+  });
+
+  it('sets CORS headers on every response', async () => {
+    const req = makeReq('OPTIONS', {});
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+
+  it('accepts a CIK that is already 10 digits', async () => {
+    const payload = { facts: {}, cik: 320193 };
+    mockSecSuccess(payload);
+
+    const req = makeReq('GET', { cik: '0000320193' });
+    const res = makeRes();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await secCompanyFactsHandler(req as any, res as any);
+
+    expect(res.statusCode).toBe(200);
+    const calledUrl = mockGet.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('CIK0000320193.json');
+  });
+});

--- a/functions/src/functions/secProxy.ts
+++ b/functions/src/functions/secProxy.ts
@@ -1,0 +1,162 @@
+import * as functions from 'firebase-functions';
+import * as https from 'https';
+import * as zlib from 'zlib';
+import type { Request, Response } from 'express';
+
+const SEC_USER_AGENT = 'edgar-value-miner (contact@example.com)';
+
+const CACHE_DURATION_SECONDS = 24 * 60 * 60; // 24 hours
+
+/**
+ * Fetches a URL from the SEC EDGAR API server-side, handling GZip decompression.
+ * Sets the required User-Agent header (SEC blocks requests without it).
+ *
+ * @param url - The SEC URL to fetch
+ * @returns Parsed JSON response
+ */
+function fetchFromSec(url: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const options = {
+      headers: {
+        'User-Agent': SEC_USER_AGENT,
+        'Accept': 'application/json',
+        'Accept-Encoding': 'gzip, deflate',
+      },
+    };
+
+    https.get(url, options, (res) => {
+      const { statusCode, headers: resHeaders } = res;
+
+      if (statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`SEC API returned status ${statusCode} for ${url}`));
+      }
+
+      const encoding = resHeaders['content-encoding'];
+      let stream: NodeJS.ReadableStream = res;
+
+      if (encoding === 'gzip') {
+        const gunzip = zlib.createGunzip();
+        res.pipe(gunzip);
+        stream = gunzip;
+      } else if (encoding === 'deflate') {
+        const inflate = zlib.createInflate();
+        res.pipe(inflate);
+        stream = inflate;
+      }
+
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('error', reject);
+      stream.on('end', () => {
+        try {
+          const body = Buffer.concat(chunks).toString('utf-8');
+          resolve(JSON.parse(body));
+        } catch (err) {
+          reject(new Error(`Failed to parse SEC JSON response from ${url}: ${(err as Error).message}`));
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+/**
+ * Sets CORS headers on the response to allow all origins.
+ */
+function setCorsHeaders(res: Response): void {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.set('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+/**
+ * secTickers — GET /api/sec-tickers
+ *
+ * Proxies https://www.sec.gov/files/company_tickers.json server-side to avoid
+ * browser CORS restrictions. SEC requires a User-Agent header that cannot be
+ * set from the browser. Response is cached for 24 hours (SEC updates daily).
+ *
+ * Usage:
+ *   GET https://<region>-<project-id>.cloudfunctions.net/secTickers
+ */
+export async function secTickersHandler(
+  req: Request,
+  res: Response
+): Promise<void> {
+  setCorsHeaders(res);
+
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  try {
+    const data = await fetchFromSec('https://www.sec.gov/files/company_tickers.json');
+    res.set('Cache-Control', `public, max-age=${CACHE_DURATION_SECONDS}, s-maxage=${CACHE_DURATION_SECONDS}`);
+    res.status(200).json(data);
+  } catch (err) {
+    const message = (err as Error).message;
+    functions.logger.error('secTickers proxy error', { message });
+    res.status(502).json({ error: 'Failed to fetch SEC tickers', detail: message });
+  }
+}
+
+/**
+ * secCompanyFacts — GET /api/sec-company-facts?cik=<CIK>
+ *
+ * Proxies https://data.sec.gov/api/xbrl/companyfacts/CIK{paddedCIK}.json
+ * server-side to avoid browser CORS restrictions.
+ * CIK is zero-padded to 10 digits as required by the SEC API.
+ * Response is cached for 24 hours.
+ *
+ * Usage:
+ *   GET https://<region>-<project-id>.cloudfunctions.net/secCompanyFacts?cik=320193
+ */
+export async function secCompanyFactsHandler(
+  req: Request,
+  res: Response
+): Promise<void> {
+  setCorsHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const cikParam = req.query['cik'];
+  if (!cikParam || typeof cikParam !== 'string' || !/^\d+$/.test(cikParam.trim())) {
+    res.status(400).json({ error: 'Missing or invalid "cik" query parameter. Must be a numeric CIK.' });
+    return;
+  }
+
+  const paddedCik = cikParam.trim().padStart(10, '0');
+  const secUrl = `https://data.sec.gov/api/xbrl/companyfacts/CIK${paddedCik}.json`;
+
+  try {
+    const data = await fetchFromSec(secUrl);
+    res.set('Cache-Control', `public, max-age=${CACHE_DURATION_SECONDS}, s-maxage=${CACHE_DURATION_SECONDS}`);
+    res.status(200).json(data);
+  } catch (err) {
+    const message = (err as Error).message;
+    const is404 = message.includes('status 404');
+
+    functions.logger.error('secCompanyFacts proxy error', { cik: paddedCik, message });
+
+    if (is404) {
+      res.status(404).json({ error: `Company with CIK ${paddedCik} not found in SEC database.` });
+    } else {
+      res.status(502).json({ error: 'Failed to fetch SEC company facts', detail: message });
+    }
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,22 @@
+import * as functions from 'firebase-functions';
+import { secTickersHandler } from './functions/secProxy';
+import { secCompanyFactsHandler } from './functions/secProxy';
+
+/**
+ * secTickers — GET proxy for https://www.sec.gov/files/company_tickers.json
+ *
+ * Bypasses browser CORS restriction. SEC blocks direct browser requests.
+ * Adds required User-Agent header server-side.
+ * Response cached 24h (SEC updates daily).
+ */
+export const secTickers = functions.https.onRequest(secTickersHandler);
+
+/**
+ * secCompanyFacts — GET proxy for https://data.sec.gov/api/xbrl/companyfacts/CIK{cik}.json
+ *
+ * Usage: GET /secCompanyFacts?cik=320193
+ * Bypasses browser CORS restriction.
+ * Adds required User-Agent header server-side.
+ * Response cached 24h.
+ */
+export const secCompanyFacts = functions.https.onRequest(secCompanyFactsHandler);

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2020",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "compileOnSave": true,
+  "include": [
+    "src"
+  ]
+}

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/src/services/__tests__/edgarApi.test.js
+++ b/src/services/__tests__/edgarApi.test.js
@@ -361,10 +361,10 @@ describe('edgarApi', () => {
     it('should pad CIK before fetching', async () => {
       await fetchCompanyFacts(320193);
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('CIK0000320193'),
-        expect.any(Object)
-      );
+      // URL contains the padded CIK — either as path segment (DEV: CIK0000320193)
+      // or as query param (PROD: ?cik=0000320193)
+      const calledUrl = global.fetch.mock.calls[0][0];
+      expect(calledUrl).toMatch(/CIK0000320193|cik=0000320193/);
     });
 
     it('should throw error for 404 not found', async () => {
@@ -406,7 +406,7 @@ describe('edgarApi', () => {
             json: () => Promise.resolve(mockCompanyTickersResponse),
           });
         }
-        if (url.includes('companyfacts')) {
+        if (url.includes('companyfacts') || url.includes('secCompanyFacts') || url.includes('sec-company-facts')) {
           return Promise.resolve({
             ok: true,
             status: 200,

--- a/src/services/edgarApi.js
+++ b/src/services/edgarApi.js
@@ -15,17 +15,34 @@
  * SEC API Configuration
  * @constant {Object}
  */
+/**
+ * Cloud Function base URL used when VITE_FUNCTIONS_BASE_URL is not set.
+ * Format: https://<region>-<project-id>.cloudfunctions.net
+ * This default targets the production project — staging deployments must set
+ * VITE_FUNCTIONS_BASE_URL explicitly in their environment.
+ */
+const FUNCTIONS_BASE_URL =
+  import.meta.env.VITE_FUNCTIONS_BASE_URL ||
+  'https://us-central1-edgar-value-miner.cloudfunctions.net';
+
 const SEC_CONFIG = {
-  /** Base URL for Company Facts API */
-  COMPANY_FACTS_BASE_URL: 'https://data.sec.gov/api/xbrl/companyfacts',
+  /**
+   * Base URL for Company Facts API.
+   * In development, Vite proxies /api/sec-company-facts to the Cloud Function emulator.
+   * In production, requests go through the secCompanyFacts Cloud Function to avoid CORS.
+   */
+  COMPANY_FACTS_BASE_URL: import.meta.env.DEV
+    ? '/api/sec-company-facts'
+    : `${FUNCTIONS_BASE_URL}/secCompanyFacts`,
   /**
    * URL for Company Tickers list.
    * In development, Vite proxies /api/sec-tickers to SEC to avoid CORS.
-   * In production, use VITE_SEC_TICKERS_PROXY_URL env var or fall back to direct SEC URL.
+   * In production, requests go through the secTickers Cloud Function to avoid CORS.
+   * VITE_SEC_TICKERS_PROXY_URL can override the default Cloud Function URL.
    */
   COMPANY_TICKERS_URL: import.meta.env.DEV
     ? '/api/sec-tickers'
-    : (import.meta.env.VITE_SEC_TICKERS_PROXY_URL || 'https://www.sec.gov/files/company_tickers.json'),
+    : (import.meta.env.VITE_SEC_TICKERS_PROXY_URL || `${FUNCTIONS_BASE_URL}/secTickers`),
   /** User-Agent header required by SEC (from environment variable) */
   USER_AGENT: import.meta.env.VITE_SEC_USER_AGENT || 'getedgar (admincontact@getedgar.com)',
   /** Maximum CIK length with leading zeros */
@@ -567,7 +584,12 @@ export async function mapTickerToCik(ticker) {
  */
 export async function fetchCompanyFacts(cik) {
   const paddedCik = padCik(cik);
-  const url = `${SEC_CONFIG.COMPANY_FACTS_BASE_URL}/CIK${paddedCik}.json`;
+  // In development the Vite proxy forwards /api/sec-company-facts/<path> directly to
+  // data.sec.gov, matching the original SEC URL structure.
+  // In production the Cloud Function accepts a ?cik= query parameter instead.
+  const url = import.meta.env.DEV
+    ? `${SEC_CONFIG.COMPANY_FACTS_BASE_URL}/CIK${paddedCik}.json`
+    : `${SEC_CONFIG.COMPANY_FACTS_BASE_URL}?cik=${paddedCik}`;
 
   try {
     const data = await fetchWithRateLimitAndRetry(

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,13 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: () => '/files/company_tickers.json',
       },
+      // Proxy SEC company facts API to avoid CORS issues in development
+      // Forwards /api/sec-company-facts/CIK{paddedCIK}.json -> data.sec.gov
+      '/api/sec-company-facts': {
+        target: 'https://data.sec.gov',
+        changeOrigin: true,
+        rewrite: (path) => path.replace('/api/sec-company-facts', '/api/xbrl/companyfacts'),
+      },
     },
   },
 })

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.js'],
-    exclude: ['**/e2e/**', '**/node_modules/**', '**/.claude/**'],
+    exclude: ['**/e2e/**', '**/node_modules/**', '**/.claude/**', 'functions/lib/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

- **Root cause:** Frontend fetches `https://www.sec.gov/files/company_tickers.json` and `https://data.sec.gov` directly from the browser — SEC blocks this with CORS, breaking search in all deployed environments
- **Fix:** Two new Firebase Cloud Functions proxy both SEC endpoints server-side, adding the required `User-Agent` header and `Cache-Control: 24h` caching
- **Frontend updated:** `edgarApi.js` production path now routes through Cloud Functions via `VITE_FUNCTIONS_BASE_URL` — never falls back to direct SEC.gov URLs

## What changed

### New Cloud Functions (`functions/src/`)
- `secTickers` — `GET /secTickers` proxies `https://www.sec.gov/files/company_tickers.json`
- `secCompanyFacts` — `GET /secCompanyFacts?cik=<CIK>` proxies `https://data.sec.gov/api/xbrl/companyfacts/CIK{paddedCIK}.json`
- Both: CORS headers (`*`), `User-Agent` header (required by SEC), `Cache-Control: max-age=86400`, GZip decompression

### Frontend (`src/services/edgarApi.js`)
- `COMPANY_FACTS_BASE_URL` and `COMPANY_TICKERS_URL` now use `VITE_FUNCTIONS_BASE_URL` in production
- Default: `https://us-central1-edgar-value-miner.cloudfunctions.net`
- Dev: Vite proxy unchanged (no behaviour change for local dev)
- `VITE_SEC_TICKERS_PROXY_URL` still works as override

### Config/tooling fixes
- `eslint.config.js`: exclude `functions/lib` (compiled CJS) from linting
- `vitest.config.js`: exclude `functions/lib` from root test runner (was picking up 22 pre-existing CJS test failures — now 55/55 files pass)
- `.env.example`: document `VITE_FUNCTIONS_BASE_URL`
- `vite.config.js`: add `/api/sec-company-facts` dev proxy

## Test plan

- [ ] Cloud Functions unit tests: `cd functions && npm test` → 17/17 pass
- [ ] Frontend unit tests: `npm test` → 1643/1643 pass, 55/55 files pass
- [ ] Deploy Cloud Functions to staging: `firebase deploy --only functions`
- [ ] Verify `GET /secTickers` returns SEC tickers JSON
- [ ] Verify `GET /secCompanyFacts?cik=320193` returns Apple company facts
- [ ] Search "AAPL" in staging — no CORS error, search resolves
- [ ] Set `VITE_FUNCTIONS_BASE_URL` in staging deploy env to staging Cloud Functions URL

## Deployment notes

Set in **staging** environment:
```
VITE_FUNCTIONS_BASE_URL=https://us-central1-edgar-value-miner-staging.cloudfunctions.net
```

Set in **production** environment:
```
VITE_FUNCTIONS_BASE_URL=https://us-central1-edgar-value-miner.cloudfunctions.net
```