### PR TITLE
fix(#197): GAAP tag selection by data recency (revenue no longer stuck at FY2018)

### DIFF
--- a/src/utils/gaapNormalizer.js
+++ b/src/utils/gaapNormalizer.js
@@ -540,16 +540,53 @@ export function findGaapTag(companyFacts, metricName) {
     return null;
   }
 
-  // Try each tag in priority order
+  // Collect all present tags with their priority index
+  const candidates = [];
   for (let i = 0; i < tags.length; i++) {
     const tag = tags[i];
     if (usGaap[tag] && usGaap[tag].units) {
-      return { tag, data: usGaap[tag], index: i };
+      candidates.push({ tag, data: usGaap[tag], index: i });
     }
   }
 
-  devLog('log', `No matching tag found for metric: ${metricName}`);
-  return null;
+  if (candidates.length === 0) {
+    devLog('log', `No matching tag found for metric: ${metricName}`);
+    return null;
+  }
+
+  // Single match — return immediately (unchanged behaviour)
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  // Multiple matches — pick the tag with the most recent max(end date).
+  // Tie-break: prefer lower priority index (earlier in the list).
+  function maxEndDate(tagData) {
+    const unitArrays = Object.values(tagData.units);
+    let latest = '';
+    for (const arr of unitArrays) {
+      if (!Array.isArray(arr)) continue;
+      for (const entry of arr) {
+        if (entry.end && entry.end > latest) latest = entry.end;
+      }
+    }
+    return latest;
+  }
+
+  let best = candidates[0];
+  let bestEnd = maxEndDate(best.data);
+
+  for (let c = 1; c < candidates.length; c++) {
+    const candidate = candidates[c];
+    const candidateEnd = maxEndDate(candidate.data);
+    if (candidateEnd > bestEnd) {
+      best = candidate;
+      bestEnd = candidateEnd;
+    }
+    // tie: keep best (lower index wins — already set)
+  }
+
+  return best;
 }
 
 /**


### PR DESCRIPTION
## Fixes #197 (stacked on #201 red gate)
**Base = `fix/200-correctness-test-gate`** (the TDD red gate), NOT develop — per the stacking plan, develop receives the combined green result only at the chain's end.

## Root cause
`findGaapTag` returned the first priority-list tag present. Apple's `Revenues` tag ends FY2018 (switched to `RevenueFromContractWithCustomerExcludingAssessedTax` in FY2019), so revenue + gross margin froze at FY2018 (shown live: $265.6B / 73.5%).

## Fix
When multiple priority tags exist, select the one with the most recent max(end date); tie-break by priority index. Single/none paths unchanged. Return shape `{tag,data,index}` preserved (verified sole caller at gaapNormalizer.js:881).

## Tests (verified locally)
- ✅ 3 BUG-1 tests green (revenue tracks FY2025, series length 5, findGaapTag picks recent tag)
- ✅ BUG-3 same-year test green too (was downstream — revenue.fy now == grossProfit.fy)
- 🔴 BUG-2 dedup test still red → fixed in #198 (next in stack)
- ✅ 33/34 in gaapNormalizer suite; no regression in prior tests

## Note
BUG-3 (#199) is largely resolved by this change; its PR will add the explicit same-year guard in useKeyMetrics as defense-in-depth.