### PR TITLE
fix(#198): dedup FY rows by fiscal year (no more duplicate FY2023 bars)

### DIFF
--- a/src/utils/gaapNormalizer.js
+++ b/src/utils/gaapNormalizer.js
@@ -687,11 +687,19 @@ export function extractTimeSeriesData(gaapTagData, periodType, options = {}) {
   });
 
   // Deduplicate by period (keep most recent filing for each period)
-  // For restated financials: sort by filed date (most recent first) so the
-  // latest filing for each period is kept when deduplicating
+  // For annual data: key on fiscal year (item.fy or year from end date) so that
+  // restatements with off-by-one-day end dates (e.g. 2023-09-30 vs 2023-10-01)
+  // that lack a frame field still collapse to one row per fiscal year.
+  // For quarterly data: keep existing frame/end keying so Q1-Q4 are not collapsed.
   const seenPeriods = new Set();
   const deduplicatedData = sortedData.filter(item => {
-    const period = item.frame || item.end;
+    let period;
+    if (periodType === 'annual') {
+      // Prefer the SEC XBRL fy field; fall back to year extracted from end date
+      period = item.fy != null ? String(item.fy) : (item.end ? String(item.end).slice(0, 4) : (item.frame || item.end));
+    } else {
+      period = item.frame || item.end;
+    }
     if (seenPeriods.has(period)) {
       return false;
     }


### PR DESCRIPTION
## Fixes #198 (stacked on #202)
**Base = `fix/197-revenue-tag-recency`** (continues the stack; develop gets the combined green result at chain end).

## Root cause
`extractTimeSeriesData` deduped on `frame || end`. 10-K/A restatements lack `frame` + have off-by-one-day `end` → same FY survived twice → duplicate rows + React key errors.

## Fix
Annual dedup keys on SEC `fy` field (fallback year-from-end); descending sort keeps the most-recent filing per fiscal year. Quarterly keying unchanged (frame||end) so Q1-Q4 aren't collapsed.

## Tests (verified locally)
- ✅ BUG-2 test green (FY2023 no-frame/off-by-one → exactly 1 row) + sentinel keeps 10-K/A value
- ✅ All 5 correctness gate tests now pass (34/34 gaapNormalizer suite)
- ✅ Full suite 1661 pass, no regression; #197 change untouched; quarterly dedup intact