### PR TITLE
fix(#199): gross-margin same-year guard (defense-in-depth)

### DIFF
--- a/src/hooks/__tests__/useKeyMetrics.test.js
+++ b/src/hooks/__tests__/useKeyMetrics.test.js
@@ -299,6 +299,34 @@ describe('useKeyMetrics', () => {
       const margin = result.current.find((m) => m.id === 'gross-margin');
       expect(margin.trend).toBe('up');
     });
+
+    it('BUG-3 same-year guard: shows "--" when grossProfit latest year != revenue latest year', () => {
+      // grossProfit latest = FY2025, revenue latest = FY2018 — cross-year mismatch
+      // The hook must NOT divide them; it must surface the unavailable sentinel ('--').
+      const data = createMockNormalizedData({
+        grossProfit: {
+          annual: [
+            { value: 200000000000, period: 'CY2025', fiscalYear: 2025, form: '10-K', confidence: 'high' },
+            { value: 169148000000, period: 'CY2023', fiscalYear: 2023, form: '10-K', confidence: 'high' },
+          ],
+          quarterly: [],
+          tag: 'GrossProfit',
+        },
+        revenue: {
+          annual: [
+            { value: 394328000000, period: 'CY2018', fiscalYear: 2018, form: '10-K', confidence: 'high' },
+            { value: 365817000000, period: 'CY2017', fiscalYear: 2017, form: '10-K', confidence: 'high' },
+          ],
+          quarterly: [],
+          tag: 'Revenues',
+        },
+      });
+
+      const { result } = renderHook(() => useKeyMetrics(data));
+
+      const margin = result.current.find((m) => m.id === 'gross-margin');
+      expect(margin.value).toBe('--');
+    });
   });
 
   // ===========================================================================

--- a/src/hooks/useKeyMetrics.js
+++ b/src/hooks/useKeyMetrics.js
@@ -174,7 +174,12 @@ export function useKeyMetrics(normalizedData, stockQuote = null) {
     let grossMarginUnit;
     let grossMarginTrend;
 
-    if (grossProfitLatest && revenueForMargin && revenueForMargin.value !== 0) {
+    if (
+      grossProfitLatest &&
+      revenueForMargin &&
+      revenueForMargin.value !== 0 &&
+      grossProfitLatest.fiscalYear === revenueForMargin.fiscalYear
+    ) {
       const currentMargin = grossProfitLatest.value / revenueForMargin.value;
       grossMarginValue = formatPercentage(currentMargin);
       grossMarginUnit = revenueForMargin.fiscalYear ? `FY${revenueForMargin.fiscalYear}` : undefined;


### PR DESCRIPTION
## Fixes #199 (stacked on #203)
**Base = `fix/198-dedup-fiscal-year`** (continues the stack).

## Context
The 73.5% cross-year artifact is already resolved by #197 (revenue tracks latest FY). This adds a guard so `useKeyMetrics` can NEVER divide gross profit and revenue from different fiscal years, even on future gapped data.

## Fix
`useKeyMetrics.js` L177: require `grossProfitLatest.fiscalYear === revenueForMargin.fiscalYear` before computing; else the card shows '--'.

## Tests (verified locally)
- ✅ New guard test: cross-year input (grossProfit FY2025 / revenue FY2018) → '--', not a bogus ratio (red before, green after)
- ✅ useKeyMetrics 62/62, gaapNormalizer gate 34/34 (96/96 combined)
- ✅ Full suite no regression; #197/#198 untouched