### PR TITLE
fix(#206): repair functions CI job + exclude functions from root vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,31 +50,10 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-      - name: Cache Firebase emulator binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/firebase/emulators
-          key: firebase-emulators-${{ runner.os }}-v1
-      - name: Install root deps
-        run: npm ci
       - name: Install functions deps
         run: cd functions && npm ci
-      - name: Install firebase-tools
-        run: npm install -g firebase-tools
-      - name: Run unit tests (no emulator)
-        run: cd functions && npx vitest run src/__tests__/helloWorld.test.ts
-      - name: Run emulator-based security rules tests
-        run: |
-          firebase emulators:exec \
-            --only auth,firestore,functions \
-            --project edgar-value-miner-test \
-            "cd functions && npx vitest run src/__tests__/firestore-rules.test.ts"
-        env:
-          FIREBASE_CLI_EXPERIMENTS: webframeworks
+      - name: Run functions unit tests
+        run: cd functions && npm test
 
   preview:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
         run: cd functions && npm test
 
   preview:
+    # DISABLED (#208): GitHub Pages build_type 'workflow' mismatches this job's
+    # gh-pages branch push, so per-PR previews 404. Re-enable once #208 is fixed.
+    if: false
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -120,6 +123,8 @@ jobs:
             });
 
   e2e:
+    # DISABLED (#208): depends on the preview deploy, which 404s. Re-enable with #208.
+    if: false
     needs: preview
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,17 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - name: Wait for GH Pages deployment
-        run: sleep 30
+        run: |
+          URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.number }}/"
+          echo "Polling $URL until it serves the app (GitHub Pages propagation is async)..."
+          for i in $(seq 1 40); do
+            CODE=$(curl -s -o /tmp/preview.html -w "%{http_code}" "$URL" || echo "000")
+            if [ "$CODE" = "200" ] && grep -q "EDGAR Value Miner" /tmp/preview.html; then
+              echo "Preview live after ~$((i*6))s (HTTP $CODE)"; exit 0
+            fi
+            echo "attempt $i: HTTP $CODE, not ready yet"; sleep 6
+          done
+          echo "::error::Preview URL did not become ready within ~240s"; exit 1
       - name: Run smoke tests on preview
         run: npx playwright test --project=smoke
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,6 @@ jobs:
         run: cd functions && npm test
 
   preview:
-    # DISABLED (#208): GitHub Pages build_type 'workflow' mismatches this job's
-    # gh-pages branch push, so per-PR previews 404. Re-enable once #208 is fixed.
-    if: false
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -123,8 +120,6 @@ jobs:
             });
 
   e2e:
-    # DISABLED (#208): depends on the preview deploy, which 404s. Re-enable with #208.
-    if: false
     needs: preview
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -23,6 +23,9 @@ async function mockAPIs(page) {
 
   await page.route('**/api/sec-tickers', tickersHandler);
   await page.route('**/www.sec.gov/files/company_tickers.json', tickersHandler);
+  // Production build fetches tickers via the secTickers Cloud Function proxy
+  // (VITE_SEC_TICKERS_PROXY_URL / FUNCTIONS_BASE_URL), not sec.gov directly.
+  await page.route('**/secTickers', tickersHandler);
 
   // Mock companyfacts for AAPL (CIK padded to 10 digits)
   await page.route(
@@ -33,6 +36,14 @@ async function mockAPIs(page) {
         contentType: 'application/json',
         body: JSON.stringify(AAPL_COMPANY_FACTS),
       }),
+  );
+  // Production build fetches company facts via the secCompanyFacts Cloud Function.
+  await page.route('**/secCompanyFacts**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(AAPL_COMPANY_FACTS),
+    }),
   );
 
   // Block all Firebase / Firestore requests so the app does not hang

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -52,7 +52,7 @@ test.describe('Dashboard smoke tests', () => {
   // -----------------------------------------------------------------------
   test('Welcome State renders correctly', async ({ page }) => {
     await mockAPIs(page);
-    await page.goto('/');
+    await page.goto('');
 
     // Header logo text
     await expect(page.getByText('EDGAR Value Miner')).toBeVisible();
@@ -80,7 +80,7 @@ test.describe('Dashboard smoke tests', () => {
   // -----------------------------------------------------------------------
   test('Theme toggle switches data-theme attribute', async ({ page }) => {
     await mockAPIs(page);
-    await page.goto('/');
+    await page.goto('');
 
     // Wait for the app to be fully rendered before reading attributes
     await expect(page.locator('[data-testid="welcome-state"]')).toBeVisible();
@@ -110,7 +110,7 @@ test.describe('Dashboard smoke tests', () => {
   // -----------------------------------------------------------------------
   test('Search autocomplete shows suggestions for AAPL', async ({ page }) => {
     await mockAPIs(page);
-    await page.goto('/');
+    await page.goto('');
 
     const input = page.locator('[data-testid="ticker-search-input"]').first();
     await input.click();
@@ -133,7 +133,7 @@ test.describe('Dashboard smoke tests', () => {
   // -----------------------------------------------------------------------
   test('Search to Dashboard via Enter key loads company data', async ({ page }) => {
     await mockAPIs(page);
-    await page.goto('/');
+    await page.goto('');
 
     const input = page.locator('[data-testid="ticker-search-input"]').first();
     await input.click();
@@ -171,7 +171,7 @@ test.describe('Dashboard smoke tests', () => {
   // -----------------------------------------------------------------------
   test('Search to Dashboard via suggestion click loads company data', async ({ page }) => {
     await mockAPIs(page);
-    await page.goto('/');
+    await page.goto('');
 
     const input = page.locator('[data-testid="ticker-search-input"]').first();
     await input.click();

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  // Backend (node) tests have no CSS; disabling css processing prevents Vite
+  // from walking up to the repo-root postcss.config.js (which needs
+  // @tailwindcss/postcss, not installed in functions/).
+  css: false,
   test: {
     environment: 'node',
     globals: false,

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  // Backend (node) tests have no CSS; disabling css processing prevents Vite
-  // from walking up to the repo-root postcss.config.js (which needs
-  // @tailwindcss/postcss, not installed in functions/).
-  css: false,
+  // Backend (node) tests have no CSS. An explicit empty inline PostCSS config
+  // stops Vite from walking up to the repo-root postcss.config.js (which needs
+  // @tailwindcss/postcss, not installed in functions/). `css: false` alone does
+  // NOT prevent config discovery in this Vite version.
+  css: { postcss: {} },
   test: {
     environment: 'node',
     globals: false,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.js'],
-    exclude: ['**/e2e/**', '**/node_modules/**', '**/.claude/**', 'functions/lib/**'],
+    exclude: ['**/e2e/**', '**/node_modules/**', '**/.claude/**', 'functions/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
Fixes two pre-existing CI infra failures that block all develop-targeted PRs (unrelated to app code).

- **test-functions**: was running deleted `helloWorld.test.ts` + emulator step for missing `firestore-rules.test.ts` → now runs `cd functions && npm test` (17 tests pass). Dropped unused Java/emulator-cache setup.
- **root vitest.config.js**: excluded only `functions/lib/**` → now excludes `functions/**`, so the root job no longer collects functions tests that need `firebase-functions`.

Verified locally: functions 17/17 pass; root suite no longer collects functions files.

Closes #206