### PR TITLE
fix: data-correctness — revenue recency, FY dedup, margin guard + CI regressions (#197-200)

### DIFF
--- a/src/hooks/__tests__/useKeyMetrics.test.js
+++ b/src/hooks/__tests__/useKeyMetrics.test.js
@@ -299,6 +299,34 @@ describe('useKeyMetrics', () => {
       const margin = result.current.find((m) => m.id === 'gross-margin');
       expect(margin.trend).toBe('up');
     });
+
+    it('BUG-3 same-year guard: shows "--" when grossProfit latest year != revenue latest year', () => {
+      // grossProfit latest = FY2025, revenue latest = FY2018 — cross-year mismatch
+      // The hook must NOT divide them; it must surface the unavailable sentinel ('--').
+      const data = createMockNormalizedData({
+        grossProfit: {
+          annual: [
+            { value: 200000000000, period: 'CY2025', fiscalYear: 2025, form: '10-K', confidence: 'high' },
+            { value: 169148000000, period: 'CY2023', fiscalYear: 2023, form: '10-K', confidence: 'high' },
+          ],
+          quarterly: [],
+          tag: 'GrossProfit',
+        },
+        revenue: {
+          annual: [
+            { value: 394328000000, period: 'CY2018', fiscalYear: 2018, form: '10-K', confidence: 'high' },
+            { value: 365817000000, period: 'CY2017', fiscalYear: 2017, form: '10-K', confidence: 'high' },
+          ],
+          quarterly: [],
+          tag: 'Revenues',
+        },
+      });
+
+      const { result } = renderHook(() => useKeyMetrics(data));
+
+      const margin = result.current.find((m) => m.id === 'gross-margin');
+      expect(margin.value).toBe('--');
+    });
   });
 
   // ===========================================================================

--- a/src/hooks/useKeyMetrics.js
+++ b/src/hooks/useKeyMetrics.js
@@ -174,7 +174,12 @@ export function useKeyMetrics(normalizedData, stockQuote = null) {
     let grossMarginUnit;
     let grossMarginTrend;
 
-    if (grossProfitLatest && revenueForMargin && revenueForMargin.value !== 0) {
+    if (
+      grossProfitLatest &&
+      revenueForMargin &&
+      revenueForMargin.value !== 0 &&
+      grossProfitLatest.fiscalYear === revenueForMargin.fiscalYear
+    ) {
       const currentMargin = grossProfitLatest.value / revenueForMargin.value;
       grossMarginValue = formatPercentage(currentMargin);
       grossMarginUnit = revenueForMargin.fiscalYear ? `FY${revenueForMargin.fiscalYear}` : undefined;

--- a/src/utils/__tests__/calculateMargins.test.js
+++ b/src/utils/__tests__/calculateMargins.test.js
@@ -17,6 +17,7 @@
  * - Mixed valid/invalid entries
  * - Chronological sorting verified
  * - Label format "FY2023" verified
+ * - CI #200: calculateMargins non-empty on full overlap (positive counterpart to same-year guard)
  */
 
 import { describe, it, expect } from 'vitest';
@@ -504,6 +505,87 @@ describe('calculateMargins', () => {
       const result = calculateMargins(metrics);
       expect(result[0].label).toBe('FY2023');
       expect(result[0].grossMargin).toBe(60.0);
+    });
+  });
+
+  // ===========================================================================
+  // CI #200 — calculateMargins non-empty on overlap (positive counterpart to
+  // the same-year guard in useKeyMetrics).
+  //
+  // When revenue AND grossProfit both cover FY2021-FY2025 (full overlap),
+  // calculateMargins must return 5 entries with non-null grossMargin for
+  // every year. This is the positive case: the year-matching join inside
+  // calculateMargins guarantees no cross-year contamination.
+  // ===========================================================================
+
+  describe('CI #200: calculateMargins non-empty on full overlap (FY2021-FY2025)', () => {
+    // Synthetic values: roughly AAPL-shaped ratios but not real filings.
+    const fullOverlapMetrics = {
+      revenue: [
+        { value: 365817000000, fiscalYear: 2021 },
+        { value: 394328000000, fiscalYear: 2022 },
+        { value: 383285000000, fiscalYear: 2023 },
+        { value: 391035000000, fiscalYear: 2024 },
+        { value: 395760000000, fiscalYear: 2025 },
+      ],
+      grossProfit: [
+        { value: 152836000000, fiscalYear: 2021 },
+        { value: 170782000000, fiscalYear: 2022 },
+        { value: 169148000000, fiscalYear: 2023 },
+        { value: 180683000000, fiscalYear: 2024 },
+        { value: 184830000000, fiscalYear: 2025 },
+      ],
+      operatingIncome: [
+        { value: 108949000000, fiscalYear: 2021 },
+        { value: 119437000000, fiscalYear: 2022 },
+        { value: 114301000000, fiscalYear: 2023 },
+        { value: 123216000000, fiscalYear: 2024 },
+        { value: 131133000000, fiscalYear: 2025 },
+      ],
+      netIncome: [
+        { value: 94680000000, fiscalYear: 2021 },
+        { value: 99803000000, fiscalYear: 2022 },
+        { value: 96995000000, fiscalYear: 2023 },
+        { value: 93736000000, fiscalYear: 2024 },
+        { value: 96150000000, fiscalYear: 2025 },
+      ],
+    };
+
+    it('returns 5 entries for a full 5-year overlap', () => {
+      const result = calculateMargins(fullOverlapMetrics);
+      expect(result).toHaveLength(5);
+    });
+
+    it('grossMargin is non-null for every overlapping year', () => {
+      const result = calculateMargins(fullOverlapMetrics);
+      result.forEach((entry) => {
+        expect(entry.grossMargin).not.toBeNull();
+      });
+    });
+
+    it('grossMargin is a finite number between 0 and 100 for each year', () => {
+      const result = calculateMargins(fullOverlapMetrics);
+      result.forEach((entry) => {
+        expect(typeof entry.grossMargin).toBe('number');
+        expect(isFinite(entry.grossMargin)).toBe(true);
+        expect(entry.grossMargin).toBeGreaterThan(0);
+        expect(entry.grossMargin).toBeLessThan(100);
+      });
+    });
+
+    it('each entry is keyed to the correct fiscal year (no cross-year mixing)', () => {
+      const result = calculateMargins(fullOverlapMetrics);
+      const years = result.map((e) => e.fiscalYear);
+      expect(years).toEqual([2021, 2022, 2023, 2024, 2025]);
+    });
+
+    it('grossMargin for FY2025 is computed from FY2025 revenue and FY2025 grossProfit only', () => {
+      const result = calculateMargins(fullOverlapMetrics);
+      const fy2025 = result.find((e) => e.fiscalYear === 2025);
+      // 184830000000 / 395760000000 * 100 = 46.7...  → 46.7
+      expect(fy2025.grossMargin).toBe(
+        Math.round((184830000000 / 395760000000) * 100 * 10) / 10
+      );
     });
   });
 

--- a/src/utils/__tests__/gaapNormalizer.test.js
+++ b/src/utils/__tests__/gaapNormalizer.test.js
@@ -705,6 +705,352 @@ describe('BUG-3/#199 gross margin same-year integrity', () => {
 });
 
 // =============================================================================
+// CI #200 — findGaapTag recency (generalized/parameterized)
+//
+// The AAPL-specific BUG-1/#197 test above uses real tag names. This block
+// asserts the RULE itself using a synthetic metric so it is not AAPL-specific:
+// when tag A is present with stale data (maxEnd=2018) and tag B is present with
+// fresher data (maxEnd=2023), findGaapTag must return tag B regardless of order.
+// =============================================================================
+
+describe('CI #200: findGaapTag recency rule (generalized)', () => {
+  /**
+   * Build a synthetic companyFacts where two tags exist for the same metric
+   * (operatingCashFlow). The first tag in GAAP_TAG_MAP has stale data (2018),
+   * the second has fresh data (2023). findGaapTag should return the fresher tag.
+   */
+  function createStaleVsFreshFacts() {
+    return createCompanyFacts({
+      facts: {
+        'us-gaap': {
+          // First tag in operatingCashFlow list — stale (only through 2018)
+          NetCashProvidedByUsedInOperatingActivities: {
+            label: 'Net Cash Provided by Operating Activities',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2016-12-31', val: 50000000000, form: '10-K', frame: 'CY2016' }),
+                createUnitEntry({ end: '2017-12-31', val: 55000000000, form: '10-K', frame: 'CY2017' }),
+                createUnitEntry({ end: '2018-12-31', val: 60000000000, form: '10-K', frame: 'CY2018' }),
+              ],
+            },
+          },
+          // Second tag in operatingCashFlow list — fresh (through 2023)
+          CashFlowsFromUsedInOperatingActivities: {
+            label: 'Cash Flows from Operating Activities',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2019-12-31', val: 65000000000, form: '10-K', frame: 'CY2019' }),
+                createUnitEntry({ end: '2020-12-31', val: 70000000000, form: '10-K', frame: 'CY2020' }),
+                createUnitEntry({ end: '2021-12-31', val: 80000000000, form: '10-K', frame: 'CY2021' }),
+                createUnitEntry({ end: '2022-12-31', val: 85000000000, form: '10-K', frame: 'CY2022' }),
+                createUnitEntry({ end: '2023-12-31', val: 90000000000, form: '10-K', frame: 'CY2023' }),
+              ],
+            },
+          },
+        },
+      },
+    });
+  }
+
+  it('returns the fresher tag even when it has a lower priority index', () => {
+    const result = findGaapTag(createStaleVsFreshFacts(), 'operatingCashFlow');
+    expect(result).not.toBeNull();
+    expect(result.tag).toBe('CashFlowsFromUsedInOperatingActivities');
+  });
+
+  it('does not return the stale first-listed tag when a fresher candidate exists', () => {
+    const result = findGaapTag(createStaleVsFreshFacts(), 'operatingCashFlow');
+    expect(result?.tag).not.toBe('NetCashProvidedByUsedInOperatingActivities');
+  });
+
+  it('latest data from the fresher tag has end year 2023', () => {
+    const result = findGaapTag(createStaleVsFreshFacts(), 'operatingCashFlow');
+    const entries = result.data.units.USD;
+    const maxEnd = entries.reduce((best, e) => (e.end > best ? e.end : best), '');
+    expect(maxEnd.slice(0, 4)).toBe('2023');
+  });
+
+  it('when both tags cover the same latest year, returns the lower-index (priority) tag', () => {
+    // Both tags end at 2023 — recency tie => priority index wins (index 0 = first tag).
+    const facts = createCompanyFacts({
+      facts: {
+        'us-gaap': {
+          NetCashProvidedByUsedInOperatingActivities: {
+            label: 'First',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2023-12-31', val: 10, form: '10-K', frame: 'CY2023' }),
+              ],
+            },
+          },
+          CashFlowsFromUsedInOperatingActivities: {
+            label: 'Second',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2023-12-31', val: 20, form: '10-K', frame: 'CY2023' }),
+              ],
+            },
+          },
+        },
+      },
+    });
+    const result = findGaapTag(facts, 'operatingCashFlow');
+    expect(result.tag).toBe('NetCashProvidedByUsedInOperatingActivities');
+  });
+});
+
+// =============================================================================
+// CI #200 — No-duplicate-fiscalYear INVARIANT across a full normalize
+//
+// Given a companyFacts with intentional duplicate annual entries in MULTIPLE
+// metrics (revenue, operatingCashFlow, grossProfit), after normalizeCompanyFacts
+// every metric's .annual array must contain zero duplicate fiscalYear values.
+// This is a general structural invariant, not just the FY2023 off-by-one case.
+// =============================================================================
+
+describe('CI #200: no-duplicate-fiscalYear invariant across full normalize', () => {
+  /**
+   * Builds companyFacts where several metrics have duplicate annual entries
+   * for the same fiscal year (simulating 10-K + 10-K/A restatements, or
+   * the same tag reported in multiple filings for the same period).
+   */
+  function createMultiMetricDuplicateFacts() {
+    // Helper: two entries for the same fiscal year with slightly different
+    // end dates (the no-frame, off-by-one-day pattern that BUG-2 triggered).
+    function dupYear(year, val1, val2) {
+      return [
+        // Original filing
+        createUnitEntry({
+          end: `${year}-09-30`,
+          val: val1,
+          form: '10-K',
+          filed: `${year + 1}-11-01`,
+          accn: `0000320193-${year + 1}-000001`,
+        }),
+        // Restatement — same FY, end date off by 1 day
+        createUnitEntry({
+          end: `${year}-10-01`,
+          val: val2,
+          form: '10-K/A',
+          filed: `${year + 2}-01-15`,
+          accn: `0000320193-${year + 2}-000012`,
+        }),
+      ];
+    }
+
+    return createCompanyFacts({
+      facts: {
+        'us-gaap': {
+          Revenues: {
+            label: 'Revenues',
+            units: {
+              USD: [
+                ...dupYear(2021, 365817000000, 365000000000),
+                ...dupYear(2022, 394328000000, 393000000000),
+                ...dupYear(2023, 383285000000, 383000000000),
+              ],
+            },
+          },
+          NetCashProvidedByUsedInOperatingActivities: {
+            label: 'Operating Cash Flow',
+            units: {
+              USD: [
+                ...dupYear(2021, 104038000000, 103000000000),
+                ...dupYear(2022, 122151000000, 121000000000),
+                ...dupYear(2023, 110543000000, 110000000000),
+              ],
+            },
+          },
+          GrossProfit: {
+            label: 'Gross Profit',
+            units: {
+              USD: [
+                ...dupYear(2021, 152836000000, 152000000000),
+                ...dupYear(2022, 170782000000, 170000000000),
+                ...dupYear(2023, 169148000000, 169000000000),
+              ],
+            },
+          },
+        },
+      },
+    });
+  }
+
+  function hasDuplicateFiscalYears(annualArray) {
+    const years = annualArray.map((d) => d.fiscalYear);
+    return years.length !== new Set(years).size;
+  }
+
+  it('revenue.annual has no duplicate fiscalYear after normalize', () => {
+    const result = normalizeCompanyFacts(createMultiMetricDuplicateFacts());
+    expect(hasDuplicateFiscalYears(result.metrics.revenue.annual)).toBe(false);
+  });
+
+  it('operatingCashFlow.annual has no duplicate fiscalYear after normalize', () => {
+    const result = normalizeCompanyFacts(createMultiMetricDuplicateFacts());
+    expect(hasDuplicateFiscalYears(result.metrics.operatingCashFlow.annual)).toBe(false);
+  });
+
+  it('grossProfit.annual has no duplicate fiscalYear after normalize', () => {
+    const result = normalizeCompanyFacts(createMultiMetricDuplicateFacts());
+    expect(hasDuplicateFiscalYears(result.metrics.grossProfit.annual)).toBe(false);
+  });
+
+  it('all metrics returned by normalizeCompanyFacts have no duplicate fiscalYears', () => {
+    const result = normalizeCompanyFacts(createMultiMetricDuplicateFacts());
+    for (const [metricName, metricData] of Object.entries(result.metrics)) {
+      const annual = metricData.annual;
+      if (!Array.isArray(annual) || annual.length === 0) continue;
+      const hasDups = hasDuplicateFiscalYears(annual);
+      expect(hasDups, `${metricName}.annual contains duplicate fiscalYears`).toBe(false);
+    }
+  });
+});
+
+// =============================================================================
+// CI #200 — AAPL-shaped smoke test (synthetic fixture, structural invariants)
+//
+// NOTE: No realistic multi-year AAPL fixture exists in e2e/fixtures/ that
+// includes both the stale "Revenues" tag AND the current
+// "RevenueFromContractWithCustomerExcludingAssessedTax" tag. The existing
+// AAPL_COMPANY_FACTS (e2e/fixtures/mock-sec-data.js) only has "Revenues" with
+// 5 clean years — it does not exercise the tag-recency bug shape. Rather than
+// fabricating real financial figures or importing an e2e fixture into a unit
+// test (which crosses test-layer boundaries), this test uses a clearly synthetic
+// AAPL-shaped inline fixture with plausible orders-of-magnitude, and asserts
+// structural invariants only (no hardcoded financial figures).
+// =============================================================================
+
+describe('CI #200: AAPL-shaped synthetic smoke test (structural invariants)', () => {
+  /**
+   * Synthetic AAPL-shaped companyFacts with:
+   * - Stale "Revenues" tag (FY2016-FY2018 only, ~$215-265B range)
+   * - Current "RevenueFromContractWithCustomerExcludingAssessedTax" (FY2019-FY2025, ~$260-395B)
+   * - "GrossProfit" tag (FY2021-FY2025, ~$150-185B)
+   * Values are plausible but NOT taken from any real filing.
+   */
+  function createAaplShapedSyntheticFacts() {
+    return createCompanyFacts({
+      cik: '0000320193',
+      entityName: 'Apple Inc. (synthetic)',
+      ticker: 'AAPL',
+      facts: {
+        'us-gaap': {
+          // Stale legacy tag — only has data through FY2018
+          Revenues: {
+            label: 'Revenues',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2016-09-24', val: 215000000000, form: '10-K', frame: 'CY2016', filed: '2016-10-26' }),
+                createUnitEntry({ end: '2017-09-30', val: 229000000000, form: '10-K', frame: 'CY2017', filed: '2017-11-03' }),
+                createUnitEntry({ end: '2018-09-29', val: 265000000000, form: '10-K', frame: 'CY2018', filed: '2018-11-05' }),
+              ],
+            },
+          },
+          // Current tag — covers FY2019-FY2025
+          RevenueFromContractWithCustomerExcludingAssessedTax: {
+            label: 'Revenue From Contract With Customer',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2019-09-28', val: 260000000000, form: '10-K', frame: 'CY2019', filed: '2019-10-31' }),
+                createUnitEntry({ end: '2020-09-26', val: 274000000000, form: '10-K', frame: 'CY2020', filed: '2020-10-30' }),
+                createUnitEntry({ end: '2021-09-25', val: 365000000000, form: '10-K', frame: 'CY2021', filed: '2021-10-29' }),
+                createUnitEntry({ end: '2022-09-24', val: 394000000000, form: '10-K', frame: 'CY2022', filed: '2022-10-28' }),
+                createUnitEntry({ end: '2023-09-30', val: 383000000000, form: '10-K', frame: 'CY2023', filed: '2023-11-03' }),
+                createUnitEntry({ end: '2024-09-28', val: 391000000000, form: '10-K', frame: 'CY2024', filed: '2024-11-01' }),
+                createUnitEntry({ end: '2025-09-27', val: 395000000000, form: '10-K', frame: 'CY2025', filed: '2025-11-04' }),
+              ],
+            },
+          },
+          // GrossProfit — covers FY2021-FY2025
+          GrossProfit: {
+            label: 'Gross Profit',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2021-09-25', val: 152000000000, form: '10-K', frame: 'CY2021', filed: '2021-10-29' }),
+                createUnitEntry({ end: '2022-09-24', val: 170000000000, form: '10-K', frame: 'CY2022', filed: '2022-10-28' }),
+                createUnitEntry({ end: '2023-09-30', val: 169000000000, form: '10-K', frame: 'CY2023', filed: '2023-11-03' }),
+                createUnitEntry({ end: '2024-09-28', val: 180000000000, form: '10-K', frame: 'CY2024', filed: '2024-11-01' }),
+                createUnitEntry({ end: '2025-09-27', val: 184000000000, form: '10-K', frame: 'CY2025', filed: '2025-11-04' }),
+              ],
+            },
+          },
+        },
+      },
+    });
+  }
+
+  let normalized;
+
+  // Normalize once, reuse across all assertions.
+  // (beforeAll not available in this style — use a module-level variable set on first access)
+  function getNormalized() {
+    if (!normalized) {
+      normalized = normalizeCompanyFacts(createAaplShapedSyntheticFacts());
+    }
+    return normalized;
+  }
+
+  it('latest revenue year is 2025 (recency rule picks current tag over stale Revenues tag)', () => {
+    const result = getNormalized();
+    expect(result.metrics.revenue.annual[0].fiscalYear).toBe(2025);
+  });
+
+  it('revenue latest value is above $300B (sane lower band for AAPL-scale)', () => {
+    const result = getNormalized();
+    const latestRevenue = result.metrics.revenue.annual[0].value;
+    expect(latestRevenue).toBeGreaterThan(300_000_000_000);
+  });
+
+  it('no annual metric contains a NaN or Infinity value', () => {
+    const result = getNormalized();
+    for (const [metricName, metricData] of Object.entries(result.metrics)) {
+      if (!Array.isArray(metricData.annual)) continue;
+      metricData.annual.forEach((entry) => {
+        expect(
+          isNaN(entry.value) || !isFinite(entry.value),
+          `${metricName} FY${entry.fiscalYear} has non-finite value: ${entry.value}`
+        ).toBe(false);
+      });
+    }
+  });
+
+  it('no annual entry has a fiscalYear more than 5 years before the latest revenue year', () => {
+    const result = getNormalized();
+    const maxYear = result.metrics.revenue.annual[0].fiscalYear;
+    const cutoff = maxYear - 5;
+    // The normalizer caps at ANNUAL_YEARS=5, so all years must be >= (maxYear - 4).
+    result.metrics.revenue.annual.forEach((entry) => {
+      expect(entry.fiscalYear).toBeGreaterThanOrEqual(cutoff);
+    });
+  });
+
+  it('gross margin for FY2025 (grossProfit/revenue) is between 0 and 1 as a ratio', () => {
+    const result = getNormalized();
+    const revEntry = result.metrics.revenue.annual.find((e) => e.fiscalYear === 2025);
+    const gpEntry = result.metrics.grossProfit.annual.find((e) => e.fiscalYear === 2025);
+    expect(revEntry).toBeDefined();
+    expect(gpEntry).toBeDefined();
+    const grossMarginRatio = gpEntry.value / revEntry.value;
+    expect(grossMarginRatio).toBeGreaterThan(0);
+    expect(grossMarginRatio).toBeLessThan(1);
+  });
+
+  it('revenue and grossProfit latest years match (no cross-year margin contamination possible)', () => {
+    const result = getNormalized();
+    const revYear = result.metrics.revenue.annual[0]?.fiscalYear;
+    const gpYear = result.metrics.grossProfit.annual[0]?.fiscalYear;
+    expect(revYear).toBe(gpYear);
+  });
+
+  it('revenue.annual has no duplicate fiscalYears', () => {
+    const result = getNormalized();
+    const years = result.metrics.revenue.annual.map((e) => e.fiscalYear);
+    expect(years.length).toBe(new Set(years).size);
+  });
+});
+
+// =============================================================================
 // Combined Edge Cases
 // =============================================================================
 

--- a/src/utils/__tests__/gaapNormalizer.test.js
+++ b/src/utils/__tests__/gaapNormalizer.test.js
@@ -13,6 +13,7 @@ import { describe, it, expect } from 'vitest';
 import {
   normalizeCompanyFacts,
   extractTimeSeriesData,
+  findGaapTag,
   NORMALIZATION_VERSION,
 } from '../../utils/gaapNormalizer.js';
 
@@ -475,6 +476,231 @@ describe('P1 #15: Missing shares outstanding', () => {
     expect(result.metrics.sharesOutstanding.annual).toEqual([]);
     expect(result.metrics.sharesOutstanding.quarterly).toEqual([]);
     expect(result.metrics.sharesOutstanding.tag).toBeNull();
+  });
+});
+
+// =============================================================================
+// BUG-1 / #197: Revenue tag recency — findGaapTag returns stale first-match
+// =============================================================================
+
+describe('BUG-1/#197 revenue tag recency', () => {
+  /**
+   * AAPL-shaped scenario: "Revenues" exists but only covers FY2016-FY2018.
+   * "RevenueFromContractWithCustomerExcludingAssessedTax" covers FY2019-FY2025.
+   * findGaapTag must return the tag with recent data, not the first-present tag.
+   */
+  function createAaplShapedFacts() {
+    return createCompanyFacts({
+      facts: {
+        'us-gaap': {
+          Revenues: {
+            label: 'Revenues',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2016-09-24', val: 215639000000, form: '10-K', frame: 'CY2016' }),
+                createUnitEntry({ end: '2017-09-30', val: 229234000000, form: '10-K', frame: 'CY2017' }),
+                createUnitEntry({ end: '2018-09-29', val: 265595000000, form: '10-K', frame: 'CY2018' }),
+              ],
+            },
+          },
+          RevenueFromContractWithCustomerExcludingAssessedTax: {
+            label: 'Revenue From Contract With Customer Excluding Assessed Tax',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2019-09-28', val: 260174000000, form: '10-K', frame: 'CY2019' }),
+                createUnitEntry({ end: '2020-09-26', val: 274515000000, form: '10-K', frame: 'CY2020' }),
+                createUnitEntry({ end: '2021-09-25', val: 365817000000, form: '10-K', frame: 'CY2021' }),
+                createUnitEntry({ end: '2022-09-24', val: 394328000000, form: '10-K', frame: 'CY2022' }),
+                createUnitEntry({ end: '2023-09-30', val: 383285000000, form: '10-K', frame: 'CY2023' }),
+                createUnitEntry({ end: '2024-09-28', val: 391035000000, form: '10-K', frame: 'CY2024' }),
+                createUnitEntry({ end: '2025-09-27', val: 395760000000, form: '10-K', frame: 'CY2025' }),
+              ],
+            },
+          },
+        },
+      },
+    });
+  }
+
+  it('normalizeCompanyFacts: most recent annual[0].fiscalYear should be 2025, not 2018', () => {
+    // BUG: findGaapTag picks "Revenues" (index 0) which only has data through FY2018.
+    // The result.metrics.revenue.annual[0].fiscalYear will be 2018 instead of 2025.
+    const result = normalizeCompanyFacts(createAaplShapedFacts());
+    expect(result.metrics.revenue.annual[0].fiscalYear).toBe(2025);
+  });
+
+  it('normalizeCompanyFacts: annual series should cover recent years (length 5, no year < 2021)', () => {
+    // BUG: today returns FY2016-FY2018 stale data (at most 3 entries from Revenues).
+    const result = normalizeCompanyFacts(createAaplShapedFacts());
+    expect(result.metrics.revenue.annual).toHaveLength(5);
+    const years = result.metrics.revenue.annual.map(d => d.fiscalYear);
+    expect(Math.min(...years)).toBeGreaterThanOrEqual(2021);
+  });
+
+  it('findGaapTag: should return RevenueFromContractWithCustomerExcludingAssessedTax, not Revenues', () => {
+    // BUG: today returns { tag: "Revenues", index: 0 } because it is first in GAAP_TAG_MAP.
+    // The correct tag is the one with more recent data.
+    const tagResult = findGaapTag(createAaplShapedFacts(), 'revenue');
+    expect(tagResult).not.toBeNull();
+    expect(tagResult.tag).toBe('RevenueFromContractWithCustomerExcludingAssessedTax');
+  });
+});
+
+// =============================================================================
+// BUG-2 / #198: Duplicate fiscal year dedup — no-frame + off-by-one-day end
+// =============================================================================
+
+describe('BUG-2/#198 duplicate fiscal year dedup (no-frame, off-by-one-day end)', () => {
+  /**
+   * Stronger than the existing "#8 restated" test.
+   * The existing test uses frame: 'CY2023' on both entries — dedup keys on frame,
+   * so it works. THIS test omits frame entirely (10-K/A restatement shape) and
+   * uses two slightly different end dates (2023-09-30 vs 2023-10-01) for the
+   * same fiscal year. The dedup key becomes item.end, which differs → both survive.
+   */
+  it('extractTimeSeriesData: FY2023 with no-frame + off-by-one-day ends → exactly 1 row', () => {
+    const gaapTagData = {
+      units: {
+        USD: [
+          // Original 10-K for FY2023
+          createUnitEntry({
+            end: '2023-09-30',
+            val: 383285000000,
+            form: '10-K',
+            // no frame — intentional, this is the bug-triggering shape
+            filed: '2023-11-03',
+            accn: '0000320193-23-000077',
+          }),
+          // 10-K/A restatement same fiscal year, end date off by 1 day
+          createUnitEntry({
+            end: '2023-10-01',
+            val: 383000000000,
+            form: '10-K/A',
+            // no frame
+            filed: '2024-01-15',
+            accn: '0000320193-24-000012',
+          }),
+        ],
+      },
+    };
+
+    const result = extractTimeSeriesData(gaapTagData, 'annual');
+
+    // BUG: dedup keys on (frame || end). Without frame, key = end.
+    // '2023-09-30' !== '2023-10-01' → both survive → length is 2, not 1.
+    const fy2023Entries = result.filter(d => d.fiscalYear === 2023);
+    expect(fy2023Entries).toHaveLength(1);
+  });
+
+  it('extractTimeSeriesData: no-frame dedup keeps the later-filed entry (10-K/A value)', () => {
+    const gaapTagData = {
+      units: {
+        USD: [
+          createUnitEntry({
+            end: '2023-09-30',
+            val: 383285000000,
+            form: '10-K',
+            filed: '2023-11-03',
+            accn: '0000320193-23-000077',
+          }),
+          createUnitEntry({
+            end: '2023-10-01',
+            val: 383000000000,
+            form: '10-K/A',
+            filed: '2024-01-15',
+            accn: '0000320193-24-000012',
+          }),
+        ],
+      },
+    };
+
+    const result = extractTimeSeriesData(gaapTagData, 'annual');
+    const fy2023 = result.find(d => d.fiscalYear === 2023);
+
+    // The 10-K/A (later-filed) should be the surviving entry
+    expect(fy2023).toBeDefined();
+    expect(fy2023.value).toBe(383000000000);
+  });
+});
+
+// =============================================================================
+// BUG-3 / #199: Gross margin same-year integrity
+//
+// The same-year guard should live in: useKeyMetrics.js, in the "Gross Margin"
+// section (lines ~177-192). Specifically, before computing:
+//   grossProfitLatest.value / revenueForMargin.value
+// the code must assert grossProfitLatest.fiscalYear === revenueForMargin.fiscalYear.
+// calculateMargins() already enforces this correctly via findByYear() join, but
+// useKeyMetrics bypasses calculateMargins and calls getLatestValue() independently
+// on each metric, allowing cross-year division when BUG-1 stales revenue.
+// =============================================================================
+
+describe('BUG-3/#199 gross margin same-year integrity', () => {
+  /**
+   * Reproduce the AAPL cross-year mismatch:
+   * - revenue resolves to FY2018 (BUG-1 stale tag path)
+   * - grossProfit resolves to FY2025 (GrossProfit tag has current data)
+   * After BUG-1 is fixed, revenue.annual[0].fiscalYear must equal
+   * grossProfit.annual[0].fiscalYear. This test encodes the invariant at the
+   * normalizedData level so it fails today (before either bug is fixed) and
+   * passes once both tags resolve to the same latest year.
+   */
+  it('normalizeCompanyFacts: revenue.annual[0].fiscalYear must equal grossProfit.annual[0].fiscalYear for AAPL-shaped data', () => {
+    const facts = createCompanyFacts({
+      facts: {
+        'us-gaap': {
+          // Stale revenue tag (FY2016-FY2018 only) — triggers BUG-1
+          Revenues: {
+            label: 'Revenues',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2016-09-24', val: 215639000000, form: '10-K', frame: 'CY2016' }),
+                createUnitEntry({ end: '2017-09-30', val: 229234000000, form: '10-K', frame: 'CY2017' }),
+                createUnitEntry({ end: '2018-09-29', val: 265595000000, form: '10-K', frame: 'CY2018' }),
+              ],
+            },
+          },
+          // Current revenue tag (FY2019-FY2025)
+          RevenueFromContractWithCustomerExcludingAssessedTax: {
+            label: 'Revenue From Contract With Customer Excluding Assessed Tax',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2019-09-28', val: 260174000000, form: '10-K', frame: 'CY2019' }),
+                createUnitEntry({ end: '2020-09-26', val: 274515000000, form: '10-K', frame: 'CY2020' }),
+                createUnitEntry({ end: '2021-09-25', val: 365817000000, form: '10-K', frame: 'CY2021' }),
+                createUnitEntry({ end: '2022-09-24', val: 394328000000, form: '10-K', frame: 'CY2022' }),
+                createUnitEntry({ end: '2023-09-30', val: 383285000000, form: '10-K', frame: 'CY2023' }),
+                createUnitEntry({ end: '2024-09-28', val: 391035000000, form: '10-K', frame: 'CY2024' }),
+                createUnitEntry({ end: '2025-09-27', val: 395760000000, form: '10-K', frame: 'CY2025' }),
+              ],
+            },
+          },
+          // GrossProfit has current data through FY2025
+          GrossProfit: {
+            label: 'Gross Profit',
+            units: {
+              USD: [
+                createUnitEntry({ end: '2021-09-25', val: 152836000000, form: '10-K', frame: 'CY2021' }),
+                createUnitEntry({ end: '2022-09-24', val: 170782000000, form: '10-K', frame: 'CY2022' }),
+                createUnitEntry({ end: '2023-09-30', val: 169148000000, form: '10-K', frame: 'CY2023' }),
+                createUnitEntry({ end: '2024-09-28', val: 180683000000, form: '10-K', frame: 'CY2024' }),
+                createUnitEntry({ end: '2025-09-27', val: 184830000000, form: '10-K', frame: 'CY2025' }),
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const result = normalizeCompanyFacts(facts);
+
+    const revYear = result.metrics.revenue.annual[0]?.fiscalYear;
+    const gpYear = result.metrics.grossProfit.annual[0]?.fiscalYear;
+
+    // BUG: today revYear = 2018 (stale Revenues tag), gpYear = 2025.
+    // A gross margin computed from these would divide FY2025 grossProfit by FY2018 revenue.
+    // After fix: both should resolve to 2025 (or at minimum, the same year).
+    expect(revYear).toBe(gpYear);
   });
 });
 

--- a/src/utils/gaapNormalizer.js
+++ b/src/utils/gaapNormalizer.js
@@ -687,11 +687,19 @@ export function extractTimeSeriesData(gaapTagData, periodType, options = {}) {
   });
 
   // Deduplicate by period (keep most recent filing for each period)
-  // For restated financials: sort by filed date (most recent first) so the
-  // latest filing for each period is kept when deduplicating
+  // For annual data: key on fiscal year (item.fy or year from end date) so that
+  // restatements with off-by-one-day end dates (e.g. 2023-09-30 vs 2023-10-01)
+  // that lack a frame field still collapse to one row per fiscal year.
+  // For quarterly data: keep existing frame/end keying so Q1-Q4 are not collapsed.
   const seenPeriods = new Set();
   const deduplicatedData = sortedData.filter(item => {
-    const period = item.frame || item.end;
+    let period;
+    if (periodType === 'annual') {
+      // Prefer the SEC XBRL fy field; fall back to year extracted from end date
+      period = item.fy != null ? String(item.fy) : (item.end ? String(item.end).slice(0, 4) : (item.frame || item.end));
+    } else {
+      period = item.frame || item.end;
+    }
     if (seenPeriods.has(period)) {
       return false;
     }

--- a/src/utils/gaapNormalizer.js
+++ b/src/utils/gaapNormalizer.js
@@ -540,16 +540,53 @@ export function findGaapTag(companyFacts, metricName) {
     return null;
   }
 
-  // Try each tag in priority order
+  // Collect all present tags with their priority index
+  const candidates = [];
   for (let i = 0; i < tags.length; i++) {
     const tag = tags[i];
     if (usGaap[tag] && usGaap[tag].units) {
-      return { tag, data: usGaap[tag], index: i };
+      candidates.push({ tag, data: usGaap[tag], index: i });
     }
   }
 
-  devLog('log', `No matching tag found for metric: ${metricName}`);
-  return null;
+  if (candidates.length === 0) {
+    devLog('log', `No matching tag found for metric: ${metricName}`);
+    return null;
+  }
+
+  // Single match — return immediately (unchanged behaviour)
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  // Multiple matches — pick the tag with the most recent max(end date).
+  // Tie-break: prefer lower priority index (earlier in the list).
+  function maxEndDate(tagData) {
+    const unitArrays = Object.values(tagData.units);
+    let latest = '';
+    for (const arr of unitArrays) {
+      if (!Array.isArray(arr)) continue;
+      for (const entry of arr) {
+        if (entry.end && entry.end > latest) latest = entry.end;
+      }
+    }
+    return latest;
+  }
+
+  let best = candidates[0];
+  let bestEnd = maxEndDate(best.data);
+
+  for (let c = 1; c < candidates.length; c++) {
+    const candidate = candidates[c];
+    const candidateEnd = maxEndDate(candidate.data);
+    if (candidateEnd > bestEnd) {
+      best = candidate;
+      bestEnd = candidateEnd;
+    }
+    // tie: keep best (lower index wins — already set)
+  }
+
+  return best;
 }
 
 /**


### PR DESCRIPTION
Fixes the 3 data-correctness bugs found by staging AAPL validation, plus CI regressions to catch them permanently. Rebuilt clean off develop (post-#207 CI fix); 5 approved commits cherry-picked.

- **fix(#197)** GAAP tag selection by data recency — revenue no longer stuck at FY2018 (root cause; AAPL deprecated `Revenues` tag ~2018).
- **fix(#198)** dedup annual series by fiscal year, latest-filing-wins — no more duplicate FY bars.
- **fix(#199)** gross-margin same-year guard — shows '--' when gross-profit FY != revenue FY (defense-in-depth).
- **test(#200)** data-correctness CI regressions: freshness (== max FY), no-dup-FY, same-year margin, 0<gm<1, AAPL sane bands, tag recency.

Logic-reviewed and approved item-by-item. 1681 unit tests pass locally (1 known flaky barrel-export timeout under parallel load, passes in isolation).

Closes #197
Closes #198
Closes #199
Closes #200