### PR TITLE
fix(#212): loop HTML-tag strip until stable (CodeQL incomplete-sanitization HIGH)

### DIFF
--- a/src/utils/__tests__/inputSanitization.test.js
+++ b/src/utils/__tests__/inputSanitization.test.js
@@ -407,3 +407,29 @@ describe('containsXss', () => {
     expect(containsXss('<div>text</div>')).toBe(true);
   });
 });
+
+// =============================================================================
+// Incomplete multi-character sanitization (CodeQL HIGH, #212)
+// A single-pass tag strip can re-create a tag from interleaved/nested markup.
+// After sanitization the result must contain NO angle brackets / tag residue.
+// =============================================================================
+describe('incomplete multi-character sanitization (#212)', () => {
+  const nestedPayloads = [
+    '<scr<script>ipt>alert(1)</scr</script>ipt>',
+    '<<script>script>alert(1)<</script>/script>',
+    '<img<img src=x> src=x onerror=alert(1)>',
+    '<<>>',
+  ];
+
+  it.each(nestedPayloads)('sanitizeTextInput leaves no tag residue for %s', (payload) => {
+    const { sanitized } = sanitizeTextInput(payload);
+    expect(sanitized).not.toMatch(/<[^>]*>/);
+    expect(sanitized).not.toContain('<script');
+  });
+
+  it.each(nestedPayloads)('sanitizeTickerInput leaves no tag residue for %s', (payload) => {
+    const { sanitized } = sanitizeTickerInput(payload);
+    // ticker allowlist also strips <>, but assert no tag survives regardless
+    expect(sanitized).not.toMatch(/<[^>]*>/);
+  });
+});

--- a/src/utils/inputSanitization.js
+++ b/src/utils/inputSanitization.js
@@ -40,6 +40,26 @@ const MAX_TICKER_LENGTH = 10;
 // =============================================================================
 
 /**
+ * Strips HTML tags repeatedly until the string stabilizes.
+ *
+ * A single-pass `.replace(/<[^>]*>/g, '')` can, in principle, leave residue
+ * that re-forms a tag once inner matches are removed. Looping until no further
+ * match guarantees no tag survives (CodeQL js/incomplete-multi-character-sanitization, #212).
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function stripHtmlTags(input) {
+  let prev;
+  let out = input;
+  do {
+    prev = out;
+    out = out.replace(HTML_TAG_PATTERN, '');
+  } while (out !== prev);
+  return out;
+}
+
+/**
  * Sanitizes a ticker symbol input string
  *
  * Removes any potentially dangerous characters and validates the input
@@ -81,7 +101,7 @@ export function sanitizeTickerInput(input) {
   // Strip HTML tags FIRST (before truncation to avoid breaking tag boundaries)
   if (HTML_TAG_PATTERN.test(working)) {
     warnings.push('Input contained HTML tags');
-    working = working.replace(HTML_TAG_PATTERN, '');
+    working = stripHtmlTags(working);
   }
 
   // Remove any characters not in the allowlist
@@ -146,7 +166,7 @@ export function sanitizeTextInput(input, options = {}) {
   // Strip HTML tags
   if (HTML_TAG_PATTERN.test(working)) {
     warnings.push('Input contained HTML tags');
-    working = working.replace(HTML_TAG_PATTERN, '');
+    working = stripHtmlTags(working);
   }
 
   return { sanitized: working.trim(), original, warnings };


### PR DESCRIPTION
Clears the CodeQL HIGH `js/incomplete-multi-character-sanitization` blocking the production release (#210).

## Change
`stripHtmlTags()` repeats the tag-strip replace until the string stabilizes; used by both `sanitizeTickerInput` and `sanitizeTextInput` (was single-pass at :84 and :149). Provably leaves no tag residue regardless of nesting.

## Tests
+8 regression tests for nested/interleaved tag payloads on both functions. Full suite 68/68 green.

Closes #212