### PR TITLE
fix(#215): SSRF barrier — fetchFromSec endpoint-key API (no user URL reaches https.get)

### DIFF
--- a/functions/src/__tests__/secProxy.test.ts
+++ b/functions/src/__tests__/secProxy.test.ts
@@ -123,7 +123,41 @@ function mockSecError(statusCode: number): void {
 // ---------------------------------------------------------------------------
 // Import handlers AFTER mocks are in place
 // ---------------------------------------------------------------------------
-import { secTickersHandler, secCompanyFactsHandler } from '../functions/secProxy.js';
+import { secTickersHandler, secCompanyFactsHandler, fetchFromSec } from '../functions/secProxy.js';
+
+// ---------------------------------------------------------------------------
+// Tests: fetchFromSec is SSRF-safe by construction (#215)
+// Callers pass a server-controlled endpoint key + a numeric CIK — never a URL.
+// ---------------------------------------------------------------------------
+describe('fetchFromSec SSRF-safe endpoint API', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('builds the tickers URL from constants (host www.sec.gov)', () => {
+    fetchFromSec('tickers').catch(() => {});
+    expect(mockGet).toHaveBeenCalled();
+    const calledUrl = mockGet.mock.calls[0][0] as string;
+    expect(calledUrl).toBe('https://www.sec.gov/files/company_tickers.json');
+  });
+
+  it('builds the companyFacts URL from a numeric CIK (host data.sec.gov, padded)', () => {
+    fetchFromSec('companyFacts', 320193).catch(() => {});
+    expect(mockGet).toHaveBeenCalled();
+    const calledUrl = mockGet.mock.calls[0][0] as string;
+    expect(calledUrl).toBe('https://data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json');
+  });
+
+  it.each([
+    undefined,
+    -1,
+    1.5,
+    NaN,
+  ])('rejects a non-integer/negative CIK (%s) without calling https.get', async (badCik) => {
+    await expect(fetchFromSec('companyFacts', badCik as number)).rejects.toThrow();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Tests: secTickersHandler

--- a/functions/src/functions/secProxy.ts
+++ b/functions/src/functions/secProxy.ts
@@ -8,27 +8,22 @@ const SEC_USER_AGENT = 'edgar-value-miner (contact@example.com)';
 const CACHE_DURATION_SECONDS = 24 * 60 * 60; // 24 hours
 
 /**
- * Fetches a URL from the SEC EDGAR API server-side, handling GZip decompression.
- * Sets the required User-Agent header (SEC blocks requests without it).
- *
- * @param url - The SEC URL to fetch
- * @returns Parsed JSON response
+ * Fully server-controlled SEC endpoint URLs. The only variable part — the CIK —
+ * is a plain integer re-derived by the server (never a user-supplied string),
+ * so no user input flows into the request URL (CodeQL js/request-forgery, #215).
  */
-function fetchFromSec(url: string): Promise<unknown> {
-  const parsedUrl = new URL(url);
+const SEC_ENDPOINTS = {
+  tickers: () => 'https://www.sec.gov/files/company_tickers.json',
+  companyFacts: (cik: number) =>
+    `https://data.sec.gov/api/xbrl/companyfacts/CIK${String(cik).padStart(10, '0')}.json`,
+} as const;
 
-  if (parsedUrl.protocol !== 'https:') {
-    throw new Error(`Invalid SEC URL protocol: ${parsedUrl.protocol}`);
-  }
-
-  if (parsedUrl.hostname !== 'data.sec.gov') {
-    throw new Error(`Invalid SEC URL host: ${parsedUrl.hostname}`);
-  }
-
-  if (!/^\/api\/xbrl\/companyfacts\/CIK\d{10}\.json$/.test(parsedUrl.pathname)) {
-    throw new Error(`Invalid SEC URL path: ${parsedUrl.pathname}`);
-  }
-
+/**
+ * Performs the actual HTTPS GET to a server-constructed SEC URL, handling GZip.
+ * `url` here is always built from SEC_ENDPOINTS (constant host + integer CIK),
+ * never from a user-supplied string.
+ */
+function httpsGetJson(url: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const options = {
       headers: {
@@ -38,12 +33,12 @@ function fetchFromSec(url: string): Promise<unknown> {
       },
     };
 
-    https.get(parsedUrl, options, (res) => {
+    https.get(url, options, (res) => {
       const { statusCode, headers: resHeaders } = res;
 
       if (statusCode !== 200) {
         res.resume();
-        return reject(new Error(`SEC API returned status ${statusCode} for ${parsedUrl.toString()}`));
+        return reject(new Error(`SEC API returned status ${statusCode} for ${url}`));
       }
 
       const encoding = resHeaders['content-encoding'];
@@ -67,11 +62,34 @@ function fetchFromSec(url: string): Promise<unknown> {
           const body = Buffer.concat(chunks).toString('utf-8');
           resolve(JSON.parse(body));
         } catch (err) {
-          reject(new Error(`Failed to parse SEC JSON response from ${parsedUrl.toString()}: ${(err as Error).message}`));
+          reject(new Error(`Failed to parse SEC JSON response from ${url}: ${(err as Error).message}`));
         }
       });
     }).on('error', reject);
   });
+}
+
+/**
+ * Fetches a SEC endpoint by server-controlled key. The endpoint URL is built
+ * entirely from SEC_ENDPOINTS constants; the only variable — cik — is coerced
+ * to a Number so no user-supplied string can influence the request URL.
+ * This is the SSRF barrier (CodeQL js/request-forgery, #215): callers never
+ * pass a URL, only an allow-listed endpoint key.
+ *
+ * @param endpoint - 'tickers' | 'companyFacts'
+ * @param cik - required numeric CIK for 'companyFacts'
+ */
+export function fetchFromSec(
+  endpoint: keyof typeof SEC_ENDPOINTS,
+  cik?: number
+): Promise<unknown> {
+  if (endpoint === 'companyFacts') {
+    if (!Number.isInteger(cik) || (cik as number) < 0) {
+      return Promise.reject(new Error('companyFacts requires a non-negative integer CIK'));
+    }
+    return httpsGetJson(SEC_ENDPOINTS.companyFacts(cik as number));
+  }
+  return httpsGetJson(SEC_ENDPOINTS.tickers());
 }
 
 /**
@@ -111,7 +129,7 @@ export async function secTickersHandler(
   }
 
   try {
-    const data = await fetchFromSec('https://www.sec.gov/files/company_tickers.json');
+    const data = await fetchFromSec('tickers');
     res.set('Cache-Control', `public, max-age=${CACHE_DURATION_SECONDS}, s-maxage=${CACHE_DURATION_SECONDS}`);
     res.status(200).json(data);
   } catch (err) {
@@ -154,11 +172,14 @@ export async function secCompanyFactsHandler(
     return;
   }
 
-  const paddedCik = cikParam.trim().padStart(10, '0');
-  const secUrl = `https://data.sec.gov/api/xbrl/companyfacts/CIK${paddedCik}.json`;
+  // Re-parse to an integer: this is the SSRF barrier. Only a Number (not the
+  // user-supplied string) is passed onward; fetchFromSec builds the URL from
+  // constants, so no user input can influence the request host or path.
+  const cikNumber = Number.parseInt(cikParam.trim(), 10);
+  const paddedCik = String(cikNumber).padStart(10, '0');
 
   try {
-    const data = await fetchFromSec(secUrl);
+    const data = await fetchFromSec('companyFacts', cikNumber);
     res.set('Cache-Control', `public, max-age=${CACHE_DURATION_SECONDS}, s-maxage=${CACHE_DURATION_SECONDS}`);
     res.status(200).json(data);
   } catch (err) {


### PR DESCRIPTION
Resolves the CodeQL CRITICAL SSRF (js/request-forgery) that reappeared on refs/pull/214/merge after the host-allowlist attempt (CodeQL didn't recognize the allowlist as a barrier).

## Fix (per CodeQL's own recommendation)
`fetchFromSec(endpoint, cik?)` — callers pass a **server-controlled key** (`'tickers'`|`'companyFacts'`), never a URL. URLs are built from `SEC_ENDPOINTS` constants; the only variable (CIK) is re-parsed to an **integer**. No user-supplied string reaches `https.get`, so taint is broken at the source.

Supersedes the Copilot autofix on develop (which only allowed `data.sec.gov` + a companyfacts path regex — that would have **broken ticker search**, since tickers come from `www.sec.gov`).

## Tests
+3 SSRF-safe tests (tickers URL constant, companyFacts numeric CIK, rejects non-integer CIK). Functions 23/23, tsc clean.

Closes #215